### PR TITLE
Some details fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+Cargo.lock
+aeb.rs
+aeb_ttrpc.rs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(SOURCES
 if(SGX)
     list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tee/sgx/trust/sgx_ecdsa_ecalls.c
                         ${CMAKE_CURRENT_SOURCE_DIR}/tee/sgx/trust/sgx_dummy.c
+                        ${CMAKE_CURRENT_SOURCE_DIR}/tee/sgx/trust/rats_syscalls.c
                         )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(GET VERSION_LIST 2 VERSION_PATCH)
 
 # Define build mode
 set(RATS_BUILD_MODE "host"
-    CACHE STRING "Select build mode for rats-tls(normal|occlum|sgx)")
+    CACHE STRING "Select build mode for librats(normal|occlum|sgx)")
 
 # Print build mode
 message(STATUS "Build Mode: ${RATS_BUILD_MODE}")

--- a/api/librats_cleanup.c
+++ b/api/librats_cleanup.c
@@ -29,8 +29,5 @@ rats_err_t librats_cleanup(rats_core_context_t *handle)
 		return -RATS_ERR_INVALID;
 	}
 
-	if (handle)
-		free(handle);
-
 	return RATS_ERR_NONE;
 }

--- a/attesters/api/rats_attester_register.c
+++ b/attesters/api/rats_attester_register.c
@@ -52,7 +52,7 @@ rats_attester_err_t rats_attester_register(const rats_attester_opts_t *opts)
 	if (opts->flags & RATS_ATTESTER_OPTS_FLAGS_CSV_GUEST) {
 		if (!is_csvguest_supported()) {
 			// clang-format off
-			RTLS_DEBUG("failed to register the attester '%s' due to lack of CSV Guest capability\n",
+			RATS_DEBUG("failed to register the attester '%s' due to lack of CSV Guest capability\n",
 				   opts->type);
 			// clang-format on
 			return -RATS_ATTESTER_ERR_CPU_UNSUPPORTED;

--- a/attesters/csv/CMakeLists.txt
+++ b/attesters/csv/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCES cleanup.c
 
 # Generate library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
-target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RTLS_LIB} crypto)
+target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
 # Install library

--- a/attesters/csv/cleanup.c
+++ b/attesters/csv/cleanup.c
@@ -9,7 +9,7 @@
 
 rats_verifier_err_t csv_attester_cleanup(rats_attester_ctx_t *ctx)
 {
-	RTLS_DEBUG("called\n");
+	RATS_DEBUG("called\n");
 
 	return RATS_ATTESTER_ERR_NONE;
 }

--- a/attesters/csv/init.c
+++ b/attesters/csv/init.c
@@ -11,7 +11,7 @@ static unsigned int dummy_private;
 
 rats_verifier_err_t csv_attester_init(rats_attester_ctx_t *ctx)
 {
-	RTLS_DEBUG("ctx %p\n", ctx);
+	RATS_DEBUG("ctx %p\n", ctx);
 
 	ctx->attester_private = &dummy_private;
 

--- a/attesters/csv/main.c
+++ b/attesters/csv/main.c
@@ -29,9 +29,9 @@ static rats_attester_opts_t csv_attester_opts = {
 
 void __attribute__((constructor)) libattester_csv_init(void)
 {
-	RTLS_DEBUG("called\n");
+	RATS_DEBUG("called\n");
 
 	rats_verifier_err_t err = rats_attester_register(&csv_attester_opts);
 	if (err != RATS_ATTESTER_ERR_NONE)
-		RTLS_DEBUG("failed to register the rats register 'csv' %#x\n", err);
+		RATS_DEBUG("failed to register the rats register 'csv' %#x\n", err);
 }

--- a/attesters/csv/pre_init.c
+++ b/attesters/csv/pre_init.c
@@ -9,13 +9,13 @@
 
 rats_verifier_err_t csv_attester_pre_init(void)
 {
-	RTLS_DEBUG("called\n");
+	RATS_DEBUG("called\n");
 
 	rats_verifier_err_t err = RATS_ATTESTER_ERR_NONE;
 
 	char *cmdline_str = "which wget 1> /dev/null 2> /dev/null";
 	if (system(cmdline_str) != 0) {
-		RTLS_ERR("please install wget for csv attest\n");
+		RATS_ERR("please install wget for csv attest\n");
 		err = -RATS_ATTESTER_ERR_NO_TOOL;
 	}
 

--- a/attesters/internal/rats_attester_select.c
+++ b/attesters/internal/rats_attester_select.c
@@ -44,7 +44,7 @@ rats_err_t rats_attester_select(rats_core_context_t *ctx, const char *name)
 
 		memcpy(attester_ctx, rats_attesters_ctx[i], sizeof(*attester_ctx));
 
-		/* Set necessary configurations from rats_tls_init() to
+		/* Set necessary configurations from rats_init() to
 		 * make init() working correctly.
 		 */
 		attester_ctx->enclave_id = ctx->config.enclave_id;

--- a/attesters/sgx-ecdsa/collect_evidence.c
+++ b/attesters/sgx-ecdsa/collect_evidence.c
@@ -34,10 +34,12 @@ sgx_status_t sgx_generate_evidence(uint8_t *hash, sgx_report_t *app_report)
 
 	sgx_target_info_t qe_target_info;
 	memset(&qe_target_info, 0, sizeof(sgx_target_info_t));
-	ocall_get_target_info(&qe_target_info);
+	sgx_status_t sgx_error = ocall_get_target_info(&qe_target_info);
+	if (SGX_SUCCESS != sgx_error)
+		return sgx_error;
 
 	/* Generate the report for the app_rats */
-	sgx_status_t sgx_error = sgx_create_report(&qe_target_info, &report_data, app_report);
+	sgx_error = sgx_create_report(&qe_target_info, &report_data, app_report);
 	return sgx_error;
 }
 #elif defined(OCCLUM)

--- a/cmake/CMakeUninstall.cmake.in
+++ b/cmake/CMakeUninstall.cmake.in
@@ -20,23 +20,23 @@ foreach(file ${files})
     endif()
 endforeach()
 
-if(EXISTS "@RATS_TLS_INSTALL_LIB_PATH@")
-        exec_program("rm" ARGS "-rf  @RATS_TLS_INSTALL_LIB_PATH@"
+if(EXISTS "@RATS_INSTALL_LIB_PATH@")
+        exec_program("rm" ARGS "-rf  @RATS_INSTALL_LIB_PATH@"
                 OUTPUT_VARIABLE rm_out
                 RETURN_VALUE rm_retval
                 )
                 if(NOT "${rm_retval}" STREQUAL 0)
-                        message(FATAL_ERROR "Problem when removing @RATS_TLS_INSTALL_LIB_PATH@")
+                        message(FATAL_ERROR "Problem when removing @RATS_INSTALL_LIB_PATH@")
                 endif()
 endif()
 
-if(EXISTS "@RATS_TLS_INSTALL_INCLUDE_PATH@")
-        exec_program("rm" ARGS "-rf  @RATS_TLS_INSTALL_INCLUDE_PATH@"
+if(EXISTS "@RATS_INSTALL_INCLUDE_PATH@")
+        exec_program("rm" ARGS "-rf  @RATS_INSTALL_INCLUDE_PATH@"
                 OUTPUT_VARIABLE rm_out
                 RETURN_VALUE rm_retval
                 )
                 if(NOT "${rm_retval}" STREQUAL 0)
-                        message(FATAL_ERROR "Problem when removing @RATS_TLS_INSTALL_INCLUDE_PATH@")
+                        message(FATAL_ERROR "Problem when removing @RATS_INSTALL_INCLUDE_PATH@")
                 endif()
 endif()
 

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -1,6 +1,5 @@
 # Normal and occlum mode
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -fPIC")
-set(RATS_TLS_LDFLAGS "-fPIC -Bsymbolic -ldl")
 set(RATS_LDFLAGS "-fPIC -Bsymbolic -ldl")
 
 if(OCCLUM)

--- a/cmake/FindSGX.cmake
+++ b/cmake/FindSGX.cmake
@@ -33,7 +33,7 @@ find_path(SGX_INCLUDE NAMES sgx.h PATHS ${SGX_INCLUDE_PATH})
 # Look for the library
 find_library(SGX_LIBRARY_DIR NAMES sgx_urts PATHS ${SGX_LIBRARY_PATH})
 
-# Handle the QUIETLY and REQUIRED arguments and set RATS_TLS_FOUND to TRUE if all listed variables are TRUE.
+# Handle the QUIETLY and REQUIRED arguments and set RATS_FOUND to TRUE if all listed variables are TRUE.
 find_package_handle_standard_args(SGX
                                   DEFAULT_MSG
                                   SGX_INCLUDE SGX_LIBRARY_DIR)

--- a/include/edl/rats_syscalls.edl
+++ b/include/edl/rats_syscalls.edl
@@ -19,9 +19,5 @@ enclave {
 				  size_t len);
 		void ocall_current_time([out] double *time);
 		void ocall_low_res_time([out] int *time);
-		size_t ocall_recv(int sockfd, [out, size=len] void *buf, size_t len, int flags)
-				  propagate_errno;
-		size_t ocall_send(int sockfd, [in, size=len] const void *buf, size_t len,
-				  int flags) propagate_errno;
 	};
 };

--- a/tee/sgx/trust/rats_syscalls.c
+++ b/tee/sgx/trust/rats_syscalls.c
@@ -20,22 +20,6 @@ void printf(const char *fmt, ...)
 	ocall_print_string(buf);
 }
 
-size_t recv(int sockfd, void *buf, size_t len, int flags)
-{
-	size_t ret;
-	sgx_status_t POSSIBLE_UNUSED sgxStatus = ocall_recv(&ret, sockfd, buf, len, flags);
-
-	return ret;
-}
-
-size_t send(int sockfd, const void *buf, size_t len, int flags)
-{
-	size_t ret;
-	sgx_status_t POSSIBLE_UNUSED sgxStatus = ocall_send(&ret, sockfd, buf, len, flags);
-
-	return ret;
-}
-
 double current_time(void)
 {
 	double curr;

--- a/tee/sgx/untrust/CMakeLists.txt
+++ b/tee/sgx/untrust/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(${INCLUDE_DIRS})
 # Set source file
 set(SOURCES sgx_ecdsa_ocall.c
             sgx_la_ocall.c
+            rats_syscalls_ocall.c
             )
 
 # Generate library

--- a/tee/sgx/untrust/rats_syscalls_ocall.c
+++ b/tee/sgx/untrust/rats_syscalls_ocall.c
@@ -1,0 +1,176 @@
+/* Copyright (c) 2021 Intel Corporation
+ * Copyright (c) 2020-2021 Alibaba Cloud
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include "rats_syscalls.h"
+#include "cpu.h"
+
+void ocall_exit(void)
+{
+	exit(EXIT_FAILURE);
+}
+
+void ocall_print_string(const char *str)
+{
+	/* Proxy/Bridge will check the length and null-terminate
+	 * the input string to prevent buffer overflow.
+	 */
+	printf("%s", str);
+}
+
+/* Copy from openenclave */
+uint64_t ocall_opendir(const char *name)
+{
+	return (uint64_t)opendir(name);
+}
+
+/* Copy from openenclave */
+int ocall_readdir(uint64_t dirp, struct ocall_dirent *entry)
+{
+	int ret = -1;
+	struct dirent *ent;
+
+	errno = 0;
+
+	if (!dirp) {
+		errno = EBADF;
+		goto done;
+	}
+
+	if (!entry) {
+		errno = EINVAL;
+		goto done;
+	}
+
+	/* Perform the readdir() operation. */
+	errno = 0;
+
+	if (!(ent = readdir((DIR *)dirp))) {
+		if (errno)
+			goto done;
+
+		ret = 1;
+		goto done;
+	}
+
+	/* Copy the local entry to the caller's entry structure. */
+	size_t len = strlen(ent->d_name);
+
+	entry->d_ino = ent->d_ino;
+	entry->d_off = ent->d_off;
+	entry->d_type = ent->d_type;
+	entry->d_reclen = sizeof(struct dirent);
+
+	if (len >= sizeof(entry->d_name)) {
+		errno = ENAMETOOLONG;
+		goto done;
+	}
+
+	memcpy(entry->d_name, ent->d_name, len + 1);
+
+	ret = 0;
+
+done:
+	return ret;
+}
+
+/* Copy from openenclave */
+int ocall_closedir(uint64_t dirp)
+{
+	errno = 0;
+
+	return closedir((DIR *)dirp);
+}
+
+ssize_t ocall_read(int fd, void *buf, size_t count)
+{
+	return read(fd, buf, count);
+}
+
+ssize_t ocall_write(int fd, const void *buf, size_t count)
+{
+	return write(fd, buf, count);
+}
+
+void ocall_getenv(const char *name, char *value, size_t len)
+{
+	memset(value, 0, len);
+
+	char *env_value = getenv(name);
+	if (env_value != NULL)
+		snprintf(value, len, "%s", env_value);
+	else
+		*value = '\0';
+}
+
+static double current_time(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	return (double)((1000000.0f * (double)tv.tv_sec + (double)tv.tv_usec) / 1000000.0f);
+}
+
+void ocall_current_time(double *time)
+{
+	if (!time)
+		return;
+
+	*time = current_time();
+
+	return;
+}
+
+void ocall_low_res_time(int *time)
+{
+	if (!time)
+		return;
+
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	*time = (int)tv.tv_sec;
+}
+
+void ocall_cpuid(int *eax, int *ebx, int *ecx, int *edx)
+{
+#if defined(__x86_64__)
+	__asm__ volatile("cpuid"
+			 : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+			 : "0"(*eax), "1"(*ebx), "2"(*ecx), "3"(*edx)
+			 : "memory");
+#else
+	/* on 32bit, ebx can NOT be used as PIC code */
+	__asm__ volatile("xchgl %%ebx, %1; cpuid; xchgl %%ebx, %1"
+			 : "=a"(*eax), "=r"(*ebx), "=c"(*ecx), "=d"(*edx)
+			 : "0"(*eax), "1"(*ebx), "2"(*ecx), "3"(*edx)
+			 : "memory");
+#endif
+}
+
+void ocall_is_sgx_dev(bool *retval, const char *dev)
+{
+	struct stat st;
+
+	if (stat(dev, &st)) {
+		*retval = false;
+		return;
+	}
+
+	*retval = S_ISCHR(st.st_mode) && (major(st.st_rdev) == SGX_DEVICE_MAJOR_NUM);
+}

--- a/verifiers/csv/CMakeLists.txt
+++ b/verifiers/csv/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCES cleanup.c
 
 # Generate library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
-target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RTLS_LIB} crypto)
+target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
 # Install library

--- a/verifiers/csv/cleanup.c
+++ b/verifiers/csv/cleanup.c
@@ -9,7 +9,7 @@
 
 rats_verifier_err_t csv_verifier_cleanup(rats_verifier_ctx_t *ctx)
 {
-	RTLS_DEBUG("called\n");
+	RATS_DEBUG("called\n");
 
 	return RATS_VERIFIER_ERR_NONE;
 }

--- a/verifiers/csv/hygoncert.c
+++ b/verifiers/csv/hygoncert.c
@@ -166,7 +166,7 @@ int sm2_compute_z_digest(uint8_t *out, const EVP_MD *digest, const uint8_t *id, 
 
 	rc = 1;
 
-	RTLS_DEBUG("[VERIFY] %s %d: ret %d\n", __func__, __LINE__, rc);
+	RATS_DEBUG("[VERIFY] %s %d: ret %d\n", __func__, __LINE__, rc);
 done:
 	OPENSSL_free(buf);
 	BN_CTX_free(ctx);
@@ -254,7 +254,7 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig, const BIGNUM 
 	if (BN_cmp(r, t) == 0)
 		ret = 1;
 
-	RTLS_DEBUG("[VERIFY] %s %d: ret %d\n", __func__, __LINE__, ret);
+	RATS_DEBUG("[VERIFY] %s %d: ret %d\n", __func__, __LINE__, ret);
 done:
 	EC_POINT_free(pt);
 	BN_CTX_free(ctx);
@@ -311,7 +311,7 @@ static BIGNUM *sm2_compute_msg_hash(const EVP_MD *digest, const EC_KEY *key, con
 	if (e == NULL)
 		SM2err(SM2_F_SM2_COMPUTE_MSG_HASH, ERR_R_INTERNAL_ERROR);
 
-	RTLS_DEBUG("[VERIFY] %s %d: BIGNUM e=%p\n", __func__, __LINE__, e);
+	RATS_DEBUG("[VERIFY] %s %d: BIGNUM e=%p\n", __func__, __LINE__, e);
 done:
 	OPENSSL_free(z);
 	EVP_MD_CTX_free(hash);
@@ -347,7 +347,7 @@ int sm2_do_verify(const EC_KEY *key, const EVP_MD *digest, const ECDSA_SIG *sig,
 
 	ret = sm2_sig_verify(key, sig, e);
 
-	RTLS_DEBUG("[VERIFY] %s %d: ret %d\n", __func__, __LINE__, ret);
+	RATS_DEBUG("[VERIFY] %s %d: ret %d\n", __func__, __LINE__, ret);
 done:
 	BN_free(e);
 	return ret;
@@ -798,63 +798,63 @@ static int sm2_verify_sig(const sm2_pubkey_t *sm2_pubkey, const uint8_t *msg, si
 
 	// convert @sm2_pubkey to EC_KEY
 	if (!(ec_key = EC_KEY_new())) {
-		RTLS_DEBUG("EC_KEY_new() fail\n");
+		RATS_DEBUG("EC_KEY_new() fail\n");
 		return -1;
 	}
 	if (!(bn_qx = BN_new())) {
-		RTLS_DEBUG("BN_new() bn_qx fail\n");
+		RATS_DEBUG("BN_new() bn_qx fail\n");
 		goto err_free_ec_key;
 	}
 	if (!(bn_qy = BN_new())) {
-		RTLS_DEBUG("BN_new() bn_qy fail\n");
+		RATS_DEBUG("BN_new() bn_qy fail\n");
 		goto err_free_bn_qx;
 	}
 	BN_bin2bn(sm2_pubkey->qx, HYGON_SM2_POINT_SIZE, bn_qx);
 	BN_bin2bn(sm2_pubkey->qy, HYGON_SM2_POINT_SIZE, bn_qy);
 
 	if (!(group = ec_group_new_from_data(sm2_curve))) {
-		RTLS_DEBUG("EC_GROUP_new_by_curve_name() fail\n");
+		RATS_DEBUG("EC_GROUP_new_by_curve_name() fail\n");
 		goto err_free_bn_qy;
 	}
 	ret = EC_KEY_set_group(ec_key, group);
 	if (ret != 1) {
-		RTLS_DEBUG("EC_KEY_set_group() fail\n");
+		RATS_DEBUG("EC_KEY_set_group() fail\n");
 		goto err_free_group;
 	}
 
 	ret = EC_KEY_set_public_key_affine_coordinates(ec_key, bn_qx, bn_qy);
 	if (ret != 1) {
-		RTLS_DEBUG("EC_KEY_set_public_key_affine_coordinates() fail\n");
+		RATS_DEBUG("EC_KEY_set_public_key_affine_coordinates() fail\n");
 		goto err_free_group;
 	}
 
 	// convert @sig to ECDSA_SIG
 	ret = -1;
 	if (!(bn_sig_r = BN_new())) {
-		RTLS_DEBUG("BN_new() bn_sig_r fail\n");
+		RATS_DEBUG("BN_new() bn_sig_r fail\n");
 		goto err_free_group;
 	}
 	if (!(bn_sig_s = BN_new())) {
-		RTLS_DEBUG("BN_new() bn_sig_s fail\n");
+		RATS_DEBUG("BN_new() bn_sig_s fail\n");
 		goto err_free_bn_sig_r;
 	}
 	BN_bin2bn(sig->r, HYGON_SM2_SIGNATURE_SIZE, bn_sig_r);
 	BN_bin2bn(sig->s, HYGON_SM2_SIGNATURE_SIZE, bn_sig_s);
 
 	if (!(ecdsa_sig = ECDSA_SIG_new())) {
-		RTLS_DEBUG("ECDSA_SIG_new() fail\n");
+		RATS_DEBUG("ECDSA_SIG_new() fail\n");
 		goto err_free_bn_sig_s;
 	}
 	ret = ECDSA_SIG_set0(ecdsa_sig, bn_sig_r, bn_sig_s);
 	if (ret != 1) {
-		RTLS_DEBUG("ECDSA_SIG_set0() fail\n");
+		RATS_DEBUG("ECDSA_SIG_set0() fail\n");
 		goto err_free_ecdsa_sig;
 	}
 
 	// verify ECDSA_SIG
 	ret = sm2_do_verify(ec_key, EVP_sm3(), ecdsa_sig, user_id->uid, user_id->len, msg, msg_len);
 	if (ret != 1)
-		RTLS_DEBUG("sm2_do_verify() ret %d\n", ret);
+		RATS_DEBUG("sm2_do_verify() ret %d\n", ret);
 
 err_free_ecdsa_sig:
 	// ECDSA_SIG_free will free bn_sig_r and bn_sig_s
@@ -901,7 +901,7 @@ static int verify_hsk_cert_signature(hygon_root_cert_t *hsk_cert)
 int verify_hsk_cert(hygon_root_cert_t *cert)
 {
 	if (cert->key_usage != KEY_USAGE_TYPE_HSK) {
-		RTLS_ERR("HSK cert key usage type invalid\n");
+		RATS_ERR("HSK cert key usage type invalid\n");
 		return -1;
 	}
 
@@ -939,17 +939,17 @@ static int verify_cek_cert_signature(hygon_root_cert_t *hsk_cert, csv_cert_t *ce
 int verify_cek_cert(hygon_root_cert_t *hsk_cert, csv_cert_t *cek_cert)
 {
 	if (cek_cert->pubkey_usage != KEY_USAGE_TYPE_CEK) {
-		RTLS_ERR("CEK cert public key usage type invalid\n");
+		RATS_ERR("CEK cert public key usage type invalid\n");
 		return -1;
 	}
 
 	if (cek_cert->sig1_usage != KEY_USAGE_TYPE_HSK) {
-		RTLS_ERR("CEK cert sig 1 usage type invalid\n");
+		RATS_ERR("CEK cert sig 1 usage type invalid\n");
 		return -1;
 	}
 
 	if (cek_cert->sig2_usage != KEY_USAGE_TYPE_INVALID) {
-		RTLS_ERR("CSV: CEK cert sig 2 usage type invalid\n");
+		RATS_ERR("CSV: CEK cert sig 2 usage type invalid\n");
 		return -1;
 	}
 
@@ -982,12 +982,12 @@ static int verify_pek_cert_signature(csv_cert_t *cek_cert, csv_cert_t *pek_cert)
 int verify_pek_cert(csv_cert_t *cek_cert, csv_cert_t *pek_cert)
 {
 	if (pek_cert->pubkey_usage != KEY_USAGE_TYPE_PEK) {
-		RTLS_ERR("CSV: PEK cert public key usage type invalid\n");
+		RATS_ERR("CSV: PEK cert public key usage type invalid\n");
 		return -1;
 	}
 
 	if (pek_cert->sig1_usage != KEY_USAGE_TYPE_CEK) {
-		RTLS_ERR("CSV: PEK cert sig 1 usage type invalid\n");
+		RATS_ERR("CSV: PEK cert sig 1 usage type invalid\n");
 		return -1;
 	}
 

--- a/verifiers/csv/init.c
+++ b/verifiers/csv/init.c
@@ -11,7 +11,7 @@ static unsigned int dummy_private;
 
 rats_verifier_err_t csv_verifier_init(rats_verifier_ctx_t *ctx)
 {
-	RTLS_DEBUG("ctx %p\n", ctx);
+	RATS_DEBUG("ctx %p\n", ctx);
 
 	ctx->verifier_private = &dummy_private;
 

--- a/verifiers/csv/main.c
+++ b/verifiers/csv/main.c
@@ -28,9 +28,9 @@ static rats_verifier_opts_t csv_verifier_opts = {
 
 void __attribute__((constructor)) libverifier_csv_init(void)
 {
-	RTLS_DEBUG("called\n");
+	RATS_DEBUG("called\n");
 
 	rats_verifier_err_t err = rats_verifier_register(&csv_verifier_opts);
 	if (err != RATS_VERIFIER_ERR_NONE)
-		RTLS_ERR("failed to register the rats verifier 'csv' %#x\n", err);
+		RATS_ERR("failed to register the rats verifier 'csv' %#x\n", err);
 }

--- a/verifiers/csv/pre_init.c
+++ b/verifiers/csv/pre_init.c
@@ -9,7 +9,7 @@
 
 rats_verifier_err_t csv_verifier_pre_init(void)
 {
-	RTLS_DEBUG("called\n");
+	RATS_DEBUG("called\n");
 
 	return RATS_VERIFIER_ERR_NONE;
 }

--- a/verifiers/csv/verify_evidence.c
+++ b/verifiers/csv/verify_evidence.c
@@ -43,14 +43,14 @@ static rats_verifier_err_t verify_cert_chain(csv_evidence *evidence)
 		     (const unsigned char *)report + CSV_ATTESTATION_REPORT_HMAC_DATA_OFFSET,
 		     CSV_ATTESTATION_REPORT_HMAC_DATA_SIZE, (unsigned char *)&hmac,
 		     sizeof(hash_block_t))) {
-		RTLS_ERR("failed to compute sm3 hmac\n");
+		RATS_ERR("failed to compute sm3 hmac\n");
 		return err;
 	}
 	if (memcmp(&hmac, &report->hmac, sizeof(hash_block_t))) {
-		RTLS_ERR("PEK and ChipId may have been tampered with\n");
+		RATS_ERR("PEK and ChipId may have been tampered with\n");
 		return err;
 	}
-	RTLS_DEBUG("check PEK and ChipId successfully\n");
+	RATS_DEBUG("check PEK and ChipId successfully\n");
 
 	/* Retrieve PEK cert and ChipId */
 	j = (offsetof(csv_attestation_report, reserved1) -
@@ -61,24 +61,24 @@ static rats_verifier_err_t verify_cert_chain(csv_evidence *evidence)
 
 	/* Verify HSK cert with HRK */
 	if (verify_hsk_cert(hsk_cert) != 1) {
-		RTLS_ERR("failed to verify HSK cert\n");
+		RATS_ERR("failed to verify HSK cert\n");
 		return err;
 	}
-	RTLS_DEBUG("verify HSK cert successfully\n");
+	RATS_DEBUG("verify HSK cert successfully\n");
 
 	/* Verify CEK cert with HSK */
 	if (verify_cek_cert(hsk_cert, cek_cert) != 1) {
-		RTLS_ERR("failed to verify CEK cert\n");
+		RATS_ERR("failed to verify CEK cert\n");
 		return err;
 	}
-	RTLS_DEBUG("verify CEK cert successfully\n");
+	RATS_DEBUG("verify CEK cert successfully\n");
 
 	/* Verigy PEK cert with CEK */
 	if (verify_pek_cert(cek_cert, pek_cert) != 1) {
-		RTLS_ERR("failed to verify PEK cert\n");
+		RATS_ERR("failed to verify PEK cert\n");
 		return err;
 	}
-	RTLS_DEBUG("verify PEK cert successfully\n");
+	RATS_DEBUG("verify PEK cert successfully\n");
 
 	return RATS_VERIFIER_ERR_NONE;
 }
@@ -90,7 +90,7 @@ static rats_verifier_err_t verify_attestation_report(csv_attestation_report *rep
 	csv_cert_t *pek_cert = (csv_cert_t *)report->pek_cert;
 
 	if (sm2_verify_attestation_report(pek_cert, report) != 1) {
-		RTLS_ERR("failed to verify csv attestation report\n");
+		RATS_ERR("failed to verify csv attestation report\n");
 		return err;
 	}
 
@@ -100,7 +100,7 @@ static rats_verifier_err_t verify_attestation_report(csv_attestation_report *rep
 rats_verifier_err_t csv_verify_evidence(rats_verifier_ctx_t *ctx, attestation_evidence_t *evidence,
 					uint8_t *hash, uint32_t hash_len)
 {
-	RTLS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
+	RATS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
 
 	rats_verifier_err_t err = -RATS_VERIFIER_ERR_UNKNOWN;
 	csv_evidence *c_evidence = (csv_evidence *)(&evidence->csv.report);
@@ -119,20 +119,20 @@ rats_verifier_err_t csv_verify_evidence(rats_verifier_ctx_t *ctx, attestation_ev
 	if (memcmp(hash, user_data,
 		   hash_len <= CSV_ATTESTATION_USER_DATA_SIZE ? hash_len :
 								CSV_ATTESTATION_USER_DATA_SIZE)) {
-		RTLS_ERR("unmatched hash value in evidence\n");
+		RATS_ERR("unmatched hash value in evidence\n");
 		return -RATS_VERIFIER_ERR_INVALID;
 	}
 
 	assert(sizeof(csv_evidence) <= sizeof(evidence->csv.report));
 	err = verify_cert_chain(c_evidence);
 	if (err != RATS_VERIFIER_ERR_NONE) {
-		RTLS_ERR("failed to verify csv cert chain\n");
+		RATS_ERR("failed to verify csv cert chain\n");
 		return err;
 	}
 
 	err = verify_attestation_report(attestation_report);
 	if (err != RATS_VERIFIER_ERR_NONE)
-		RTLS_ERR("failed to verify csv attestation report\n");
+		RATS_ERR("failed to verify csv attestation report\n");
 
 	return err;
 }

--- a/verifiers/sgx-ecdsa/verify_evidence.c
+++ b/verifiers/sgx-ecdsa/verify_evidence.c
@@ -191,8 +191,10 @@ rats_verifier_err_t sgx_ecdsa_verify_evidence(rats_verifier_ctx_t *ctx,
 #elif defined(SGX)
 	sgx_ecdsa_ctx_t *ecdsa_ctx = (sgx_ecdsa_ctx_t *)ctx->verifier_private;
 	sgx_enclave_id_t eid = (sgx_enclave_id_t)ecdsa_ctx->eid;
-	ocall_ecdsa_verify_evidence(&err, ctx, eid, ctx->opts->name, evidence,
+	sgx_status_t sgx_ret = ocall_ecdsa_verify_evidence(&err, ctx, eid, ctx->opts->name, evidence,
 				    sizeof(attestation_evidence_t), hash, hash_len);
+	if (sgx_ret != SGX_SUCCESS || err != RATS_VERIFIER_ERR_NONE) 
+		RATS_ERR("failed to verify ecdsa, %04x, %04x\n", sgx_ret, err);
 #else
 	err = ecdsa_verify_evidence(ctx, ctx->opts->name, evidence, sizeof(attestation_evidence_t),
 				    hash, hash_len);


### PR DESCRIPTION
Including:

1. Fix the lack of `syscalls_ocall` and delete some useless ocalls like `ocall_recv` and `ocall_send`.
2. Add the missing error judgement in some functions.
3. Delete free() in function `librats_cleanup`, it may cause segmentation fault if the handle was allocated on the stack.
4. Replace "RTLS" with "RATS" in the csv module.
 
Morever, I suggest add some additional description to README in how to build librats in sgx with HW mode (-DSGX_HW=1)