### PR TITLE
Remove system() and bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
  - make
  - autoconf
  - libtool
+ - libcurl
  - gcc
  - g++ (ubuntu 18.04)
  - SGX driver, Intel SGX SDK & PSW: Please refer to this [guide](https://download.01.org/intel-sgx/sgx-linux/2.14/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf) to install.

--- a/attesters/csv/CMakeLists.txt
+++ b/attesters/csv/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCES cleanup.c
 
 # Generate library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
-target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto)
+target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto curl)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
 # Install library

--- a/attesters/csv/cleanup.c
+++ b/attesters/csv/cleanup.c
@@ -7,7 +7,7 @@
 #include <librats/attester.h>
 #include <librats/log.h>
 
-rats_verifier_err_t csv_attester_cleanup(rats_attester_ctx_t *ctx)
+rats_attester_err_t csv_attester_cleanup(rats_attester_ctx_t *ctx)
 {
 	RATS_DEBUG("called\n");
 

--- a/attesters/csv/collect_evidence.c
+++ b/attesters/csv/collect_evidence.c
@@ -95,14 +95,13 @@ static int load_hsk_cek_cert(uint8_t *hsk_cek_cert, const char *chip_id)
 {
 	/* Download HSK and CEK cert by ChipId */
 	const char filename[] = HYGON_HSK_CEK_CERT_FILENAME;
-	char cmdline_str[200] = {
+	char url[200] = {
 		0,
 	};
-	int count = snprintf(cmdline_str, sizeof(cmdline_str), "wget -O %s %s%s", filename,
-			     HYGON_KDS_SERVER_SITE, chip_id);
-	cmdline_str[count] = '\0';
+	int count = snprintf(url, sizeof(url), "%s%s", HYGON_KDS_SERVER_SITE, chip_id);
+	url[count] = '\0';
 
-	if (system(cmdline_str) != 0) {
+	if (download_from_url(url, filename) != 0) {
 		RATS_ERR("failed to download %s by %s\n", filename, chip_id);
 		return -1;
 	}
@@ -177,7 +176,7 @@ static int collect_attestation_evidence(uint8_t *hash, uint32_t hash_len,
 	/* Prepare user defined data (challenge and mnonce) */
 	memcpy(user_data->data, hash,
 	       hash_len <= CSV_ATTESTATION_USER_DATA_SIZE ? hash_len :
-							    CSV_ATTESTATION_USER_DATA_SIZE);
+								  CSV_ATTESTATION_USER_DATA_SIZE);
 	gen_random_bytes(user_data->mnonce, CSV_ATTESTATION_MNONCE_SIZE);
 
 	/* Prepare hash of user defined data */
@@ -232,7 +231,7 @@ err_munmap:
 	return ret;
 }
 
-rats_verifier_err_t csv_collect_evidence(rats_attester_ctx_t *ctx, attestation_evidence_t *evidence,
+rats_attester_err_t csv_collect_evidence(rats_attester_ctx_t *ctx, attestation_evidence_t *evidence,
 					 uint8_t *hash, __attribute__((unused)) uint32_t hash_len)
 {
 	RATS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);

--- a/attesters/csv/init.c
+++ b/attesters/csv/init.c
@@ -9,7 +9,7 @@
 
 static unsigned int dummy_private;
 
-rats_verifier_err_t csv_attester_init(rats_attester_ctx_t *ctx)
+rats_attester_err_t csv_attester_init(rats_attester_ctx_t *ctx)
 {
 	RATS_DEBUG("ctx %p\n", ctx);
 

--- a/attesters/csv/main.c
+++ b/attesters/csv/main.c
@@ -8,13 +8,13 @@
 #include <librats/attester.h>
 #include <librats/log.h>
 
-extern rats_verifier_err_t rats_attester_register(rats_attester_opts_t *opts);
-extern rats_verifier_err_t csv_attester_pre_init(void);
-extern rats_verifier_err_t csv_attester_init(rats_attester_ctx_t *ctx);
-extern rats_verifier_err_t csv_collect_evidence(rats_attester_ctx_t *ctx,
+extern rats_attester_err_t rats_attester_register(rats_attester_opts_t *opts);
+extern rats_attester_err_t csv_attester_pre_init(void);
+extern rats_attester_err_t csv_attester_init(rats_attester_ctx_t *ctx);
+extern rats_attester_err_t csv_collect_evidence(rats_attester_ctx_t *ctx,
 						attestation_evidence_t *evidence, uint8_t *hash,
 						uint32_t hash_len);
-extern rats_verifier_err_t csv_attester_cleanup(rats_attester_ctx_t *ctx);
+extern rats_attester_err_t csv_attester_cleanup(rats_attester_ctx_t *ctx);
 
 static rats_attester_opts_t csv_attester_opts = {
 	.api_version = RATS_ATTESTER_API_VERSION_DEFAULT,
@@ -31,7 +31,7 @@ void __attribute__((constructor)) libattester_csv_init(void)
 {
 	RATS_DEBUG("called\n");
 
-	rats_verifier_err_t err = rats_attester_register(&csv_attester_opts);
+	rats_attester_err_t err = rats_attester_register(&csv_attester_opts);
 	if (err != RATS_ATTESTER_ERR_NONE)
 		RATS_DEBUG("failed to register the rats register 'csv' %#x\n", err);
 }

--- a/attesters/csv/pre_init.c
+++ b/attesters/csv/pre_init.c
@@ -7,17 +7,9 @@
 #include <librats/attester.h>
 #include <librats/log.h>
 
-rats_verifier_err_t csv_attester_pre_init(void)
+rats_attester_err_t csv_attester_pre_init(void)
 {
 	RATS_DEBUG("called\n");
 
-	rats_verifier_err_t err = RATS_ATTESTER_ERR_NONE;
-
-	char *cmdline_str = "which wget 1> /dev/null 2> /dev/null";
-	if (system(cmdline_str) != 0) {
-		RATS_ERR("please install wget for csv attest\n");
-		err = -RATS_ATTESTER_ERR_NO_TOOL;
-	}
-
-	return err;
+	return RATS_ATTESTER_ERR_NONE;
 }

--- a/attesters/sev-snp/CMakeLists.txt
+++ b/attesters/sev-snp/CMakeLists.txt
@@ -6,7 +6,6 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  ${CMAKE_CURRENT_SOURCE_DIR}
-                 /usr/include
                  )
 include_directories(${INCLUDE_DIRS})
 
@@ -27,7 +26,7 @@ set(SOURCES cleanup.c
 
 # Generate library
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
-    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB})
+    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} curl)
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
     # Install library
     install(TARGETS ${PROJECT_NAME}

--- a/attesters/sev-snp/collect_evidence.c
+++ b/attesters/sev-snp/collect_evidence.c
@@ -15,24 +15,28 @@
 #include <linux/sev-guest.h>
 #include <librats/attester.h>
 #include <librats/log.h>
+#include <curl/curl.h>
 #include "sev_snp.h"
 
 #define SEV_GUEST_DEVICE "/dev/sev-guest"
+#define KDS_CERT_SITE	 "https://kdsintf.amd.com"
+#define KDS_VCEK	 KDS_CERT_SITE "/vcek/v1/"
+#define CURL_RETRY_TIMES 5
 
 static int snp_get_report(const uint8_t *data, size_t data_size, snp_attestation_report_t *report)
 {
 	struct snp_report_req req;
 	struct snp_report_resp resp;
 	struct snp_guest_request_ioctl guest_req;
-	snp_msg_report_rsp_t *report_resp = (struct msg_report_resp *)&resp.data;
+	snp_msg_report_rsp_t *report_resp = (struct snp_msg_report_rsp *)&resp.data;
 
-	if (data && (data_size > sizeof(req.user_data) || data_size == 0) || !data || !report)
+	if ((data && data_size > sizeof(req.user_data)) || !report)
 		return -1;
 
 	/* Initialize data structures */
 	memset(&req, 0, sizeof(req));
 	req.vmpl = 1;
-	if (data)
+	if (data && data_size)
 		memcpy(&req.user_data, data, data_size);
 
 	memset(&resp, 0, sizeof(resp));
@@ -80,6 +84,90 @@ out_close:
 	return -1;
 }
 
+static size_t curl_writefunc_callback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+	size_t realsize = size * nmemb;
+	snp_attestation_evidence_t *snp_report = (snp_attestation_evidence_t *)userp;
+
+	if (snp_report->vcek_len + realsize > VECK_MAX_SIZE) {
+		RATS_ERR("vcek size is larger than %d bytes.", VECK_MAX_SIZE);
+		return 0;
+	}
+	memcpy(&(snp_report->vcek[snp_report->vcek_len]), contents, realsize);
+	snp_report->vcek_len += realsize;
+	snp_report->vcek[snp_report->vcek_len] = 0;
+
+	return realsize;
+}
+
+rats_attester_err_t sev_snp_get_vcek_der(const uint8_t *chip_id, size_t chip_id_size,
+					 const snp_tcb_version_t *tcb,
+					 snp_attestation_evidence_t *snp_report)
+{
+	/* clear the vcek in snp_report */
+	memset(snp_report->vcek, 0, VECK_MAX_SIZE);
+	snp_report->vcek_len = 0;
+
+	/* 2 chars per byte +1 for null term */
+	char id_buf[chip_id_size * 2 + 1];
+	memset(id_buf, 0, sizeof(id_buf));
+	for (uint8_t i = 0; i < chip_id_size; i++) {
+		sprintf(id_buf + 2 * i * sizeof(uint8_t), "%02x", chip_id[i]);
+	}
+
+	int count = 0;
+	char url[256] = {
+		0,
+	};
+
+	count = snprintf(url, sizeof(url), "%sMilan/%s", KDS_VCEK, id_buf);
+
+	char *TCBStringArray[8];
+	TCBStringArray[0] = "blSPL=";
+	TCBStringArray[1] = "teeSPL=";
+	TCBStringArray[2] = "reserved0SPL=";
+	TCBStringArray[3] = "reserved1SPL=";
+	TCBStringArray[4] = "reserved2SPL=";
+	TCBStringArray[5] = "reserved3SPL=";
+	TCBStringArray[6] = "snpSPL=";
+	TCBStringArray[7] = "ucodeSPL=";
+
+	/* Generate VCEK cert correspond to @chip_id and @tcb */
+	count += snprintf((char *)&url[count], sizeof(url) - count, "?%s%02u&%s%02u&%s%02u&%s%02u",
+			  TCBStringArray[0], (unsigned)tcb->f.boot_loader, TCBStringArray[1],
+			  (unsigned)tcb->f.tee, TCBStringArray[6], (unsigned)tcb->f.snp,
+			  TCBStringArray[7], (unsigned)tcb->f.microcode);
+
+	url[count] = '\0';
+	// init curl
+	CURLcode curl_ret = CURLE_OK;
+	CURL *curl = curl_easy_init();
+	if (!curl) {
+		RATS_ERR("failed to init curl.");
+		return RATS_ATTESTER_ERR_NO_TOOL;
+	}
+
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_writefunc_callback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)snp_report);
+	for (int i = 0; i < CURL_RETRY_TIMES; i++) {
+		if ((curl_ret = curl_easy_perform(curl)) == CURLE_OK) {
+			break;
+		}
+		RATS_DEBUG("failed to download vcek_der, try again.");
+	}
+	curl_easy_cleanup(curl);
+	if (curl_ret != CURLE_OK) {
+		RATS_ERR("failed to download vcek_der after %d retries,%s\n", CURL_RETRY_TIMES,
+			 curl_easy_strerror(curl_ret));
+		return RATS_ATTESTER_ERR_CURL;
+	}
+
+	return RATS_ATTESTER_ERR_NONE;
+}
+
 rats_attester_err_t sev_snp_collect_evidence(rats_attester_ctx_t *ctx,
 					     attestation_evidence_t *evidence, uint8_t *hash,
 					     uint32_t hash_len)
@@ -100,7 +188,11 @@ rats_attester_err_t sev_snp_collect_evidence(rats_attester_ctx_t *ctx,
 
 	snprintf(evidence->type, sizeof(evidence->type), "sev_snp");
 
-	RATS_DEBUG("ctx %p, evidence %p, report_len %d\n", ctx, evidence, evidence->snp.report_len);
+	rats_attester_err_t err = sev_snp_get_vcek_der(report.chip_id, sizeof(report.chip_id),
+						       &report.platform_version, snp_report);
+	if (err != RATS_ATTESTER_ERR_NONE) {
+		return err;
+	}
 
 	return RATS_ATTESTER_ERR_NONE;
 }

--- a/include/librats/err.h
+++ b/include/librats/err.h
@@ -60,6 +60,7 @@ typedef enum {
 	RATS_ATTESTER_ERR_INVALID,
 	RATS_ATTESTER_ERR_CPU_UNSUPPORTED,
 	RATS_ATTESTER_ERR_NO_TOOL,
+	RATS_ATTESTER_ERR_CURL,
 } rats_attester_err_t;
 
 typedef enum {

--- a/include/librats/evidence.h
+++ b/include/librats/evidence.h
@@ -7,6 +7,8 @@
 #ifndef _LIBRATS_EVIDENCE_H
 #define _LIBRATS_EVIDENCE_H
 
+#define VECK_MAX_SIZE 2*1024
+
 typedef struct attestation_evidence attestation_evidence_t;
 
 typedef struct attestation_verification_report {
@@ -38,6 +40,8 @@ typedef struct tdx_attestation_evidence {
 typedef struct snp_attestation_evidence {
 	uint8_t report[8192];
 	uint32_t report_len;
+	uint8_t vcek[VECK_MAX_SIZE];
+	uint32_t vcek_len;
 } snp_attestation_evidence_t;
 
 typedef struct sev_attestation_evidence {

--- a/verifiers/sev-snp/CMakeLists.txt
+++ b/verifiers/sev-snp/CMakeLists.txt
@@ -6,7 +6,6 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  ${CMAKE_CURRENT_SOURCE_DIR}
-                 /usr/include
                  )
 include_directories(${INCLUDE_DIRS})
 

--- a/verifiers/sev-snp/pre_init.c
+++ b/verifiers/sev-snp/pre_init.c
@@ -14,24 +14,5 @@ rats_verifier_err_t sev_snp_verifier_pre_init(void)
 {
 	RATS_DEBUG("called\n");
 
-	rats_verifier_err_t err = RATS_VERIFIER_ERR_NONE;
-
-	/* These tools are used to verify SEV-SNP report */
-	char tools_name[TOOL_NUM][TOOL_NAME] = { "openssl", "wget", "csplit" };
-	char cmdline_str[50] = {
-		0,
-	};
-
-	for (int i = 0; i < TOOL_NUM; i++) {
-		int count = snprintf(cmdline_str, sizeof(cmdline_str),
-				     "which %s 1> /dev/null 2> /dev/null", tools_name[i]);
-		cmdline_str[count] = '\0';
-
-		if (system(cmdline_str) != 0) {
-			RATS_ERR("please install tool %s\n", tools_name[i]);
-			err = -RATS_VERIFIER_ERR_NO_TOOL;
-		}
-	}
-
-	return err;
+	return RATS_VERIFIER_ERR_NONE;
 }

--- a/verifiers/sev-snp/utils.c
+++ b/verifiers/sev-snp/utils.c
@@ -11,16 +11,6 @@
 #include <sys/stat.h>
 #include "utils.h"
 
-int get_file_size(char *name)
-{
-	struct stat statbuf;
-
-	if (stat(name, &statbuf) == 0)
-		return statbuf.st_size;
-
-	return 0;
-}
-
 bool reverse_bytes(uint8_t *bytes, size_t size)
 {
 	uint8_t *start = bytes;

--- a/verifiers/sev-snp/utils.h
+++ b/verifiers/sev-snp/utils.h
@@ -10,21 +10,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* Store the SEV-SNP certs downloaded from AMD KDS */
-#define SEV_SNP_DEFAULT_DIR "/opt/sev-snp/"
-
-#define KDS_CERT_SITE "https://kdsintf.amd.com"
-#define KDS_CEK	      KDS_CERT_SITE "/cek/id/"
-#define KDS_VCEK      KDS_CERT_SITE "/vcek/v1/"
-
-#define KDS_VCEK_CERT_CHAIN	     "cert_chain"
-#define VCEK_CERT_CHAIN_PEM_FILENAME "cert_chain.pem"
-#define VCEK_DER_FILENAME	     "vcek.der"
-#define VCEK_PEM_FILENAME	     "vcek.pem"
-#define VCEK_ASK_PEM_FILENAME	     "ask.pem"
-#define VCEK_ARK_PEM_FILENAME	     "ark.pem"
-
-int get_file_size(char *name);
 bool reverse_bytes(uint8_t *bytes, size_t size);
 
 #endif /* _UTILS_H */

--- a/verifiers/sev-snp/verify_evidence.c
+++ b/verifiers/sev-snp/verify_evidence.c
@@ -8,6 +8,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <openssl/ssl.h>
+#include <openssl/bio.h>
 #include <openssl/ossl_typ.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
@@ -19,124 +20,17 @@
 #include "crypto.h"
 #include "utils.h"
 
-char *vcek_pem_path = SEV_SNP_DEFAULT_DIR VCEK_PEM_FILENAME;
-char *ark_pem_path = SEV_SNP_DEFAULT_DIR VCEK_ARK_PEM_FILENAME;
-char *ask_pem_path = SEV_SNP_DEFAULT_DIR VCEK_ASK_PEM_FILENAME;
-
-int generate_vcek_pem(const uint8_t *chip_id, size_t chip_id_size, const snp_tcb_version_t *tcb)
+rats_verifier_err_t sev_snp_verify_evidence(rats_verifier_ctx_t *ctx,
+					    attestation_evidence_t *evidence, uint8_t *hash,
+					    uint32_t hash_len)
 {
-	int cmd_ret = -1;
-	struct stat st;
+	RATS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
 
-	if (stat(SEV_SNP_DEFAULT_DIR, &st) == -1) {
-		if (mkdir(SEV_SNP_DEFAULT_DIR, S_IRWXU) == -1) {
-			RATS_ERR("failed to mkdir %s\n", SEV_SNP_DEFAULT_DIR);
-			return cmd_ret;
-		}
-	}
-
-	int count = 0;
-	char cmdline_str[300] = {
-		0,
-	};
-	char *vcek_der_path = SEV_SNP_DEFAULT_DIR VCEK_DER_FILENAME;
-
-	/* 2 chars per byte +1 for null term */
-	char id_buf[chip_id_size * 2 + 1];
-	memset(id_buf, 0, sizeof(id_buf));
-	for (uint8_t i = 0; i < chip_id_size; i++) {
-		sprintf(id_buf + 2 * i * sizeof(uint8_t), "%02x", chip_id[i]);
-	}
-	count = snprintf(cmdline_str, sizeof(cmdline_str), "wget -O %s \"%sMilan/%s", vcek_der_path,
-			 KDS_VCEK, id_buf);
-
-	char *TCBStringArray[8];
-	TCBStringArray[0] = "blSPL=";
-	TCBStringArray[1] = "teeSPL=";
-	TCBStringArray[2] = "reserved0SPL=";
-	TCBStringArray[3] = "reserved1SPL=";
-	TCBStringArray[4] = "reserved2SPL=";
-	TCBStringArray[5] = "reserved3SPL=";
-	TCBStringArray[6] = "snpSPL=";
-	TCBStringArray[7] = "ucodeSPL=";
-
-	/* Generate VCEK cert correspond to @chip_id and @tcb */
-	count += snprintf((char *)&cmdline_str[count], sizeof(cmdline_str) - count,
-			  "?%s%02u&%s%02u&%s%02u&%s%02u\"", TCBStringArray[0],
-			  (unsigned)tcb->f.boot_loader, TCBStringArray[1], (unsigned)tcb->f.tee,
-			  TCBStringArray[6], (unsigned)tcb->f.snp, TCBStringArray[7],
-			  (unsigned)tcb->f.microcode);
-	cmdline_str[count] = '\0';
-
-	/* Don't re-download the VCEK from the KDS server if you already have it */
-	if (get_file_size(vcek_der_path) == 0) {
-		if (system(cmdline_str) != 0) {
-			RATS_ERR("failed to download %s\n", vcek_der_path);
-			return cmd_ret;
-		}
-	}
-
-	cmd_ret = convert_der_to_pem(vcek_der_path, vcek_pem_path);
-	if (cmd_ret == -1)
-		RATS_ERR("failed to convert %s to %s\n", vcek_der_path, vcek_pem_path);
-
-	return cmd_ret;
-}
-
-int generate_ark_ask_pem(void)
-{
-	int cmd_ret = -1;
-	int count = 0;
-	char cmdline_str[200] = {
-		0,
-	};
-	char *cert_chain_pem_path = SEV_SNP_DEFAULT_DIR VCEK_CERT_CHAIN_PEM_FILENAME;
-
-	count = snprintf(cmdline_str, sizeof(cmdline_str), "wget --no-proxy -O %s %sMilan/%s",
-			 cert_chain_pem_path, KDS_VCEK, KDS_VCEK_CERT_CHAIN);
-	cmdline_str[count] = '\0';
-
-	/* Don't re-download the cert chain from the KDS server if you already have it */
-	if (get_file_size(cert_chain_pem_path) == 0) {
-		if (system(cmdline_str) != 0) {
-			RATS_ERR("failed to download %s\n", cert_chain_pem_path);
-			return cmd_ret;
-		}
-	}
-
-	/* Split cert_chain.pem to two pem files */
-	count = snprintf(
-		cmdline_str, sizeof(cmdline_str),
-		"csplit -z -f cert_chain- %s '/-----BEGIN CERTIFICATE-----/' '{*}' 1> /dev/null 2> /dev/null",
-		cert_chain_pem_path);
-	cmdline_str[count] = '\0';
-
-	if (system(cmdline_str) != 0) {
-		RATS_ERR("failed to split cert_chain.pem\n");
-		return cmd_ret;
-	}
-
-	/* Rename the file from "cert_chain-00" to ask.pem */
-	cmd_ret = rename("cert_chain-00", ask_pem_path);
-	if (cmd_ret != 0) {
-		RATS_ERR("Error: renaming vcek cert chain file\n");
-		return cmd_ret;
-	}
-
-	/* Rename the file from "cert_chain-01" to ark.pem */
-	cmd_ret = rename("cert_chain-01", ark_pem_path);
-	if (cmd_ret != 0) {
-		RATS_ERR("Error: renaming vcek cert chain file\n");
-		return cmd_ret;
-	}
-
-	return cmd_ret;
-}
-
-rats_verifier_err_t validate_cert_chain_vcek(snp_attestation_report_t *report, uint8_t *hash,
-					     uint32_t hash_len)
-{
 	rats_verifier_err_t err = -RATS_VERIFIER_ERR_UNKNOWN;
+	snp_attestation_report_t *report = (snp_attestation_report_t *)(evidence->snp.report);
+	if (evidence->snp.vcek[0] == '\0') {
+		return RATS_VERIFIER_ERR_INVALID;
+	}
 
 	/* Verify the hash value */
 	if (memcmp(hash, report->report_data, hash_len) != 0) {
@@ -148,14 +42,29 @@ rats_verifier_err_t validate_cert_chain_vcek(snp_attestation_report_t *report, u
 	X509 *x509_ask = NULL;
 	X509 *x509_vcek = NULL;
 	EVP_PKEY *vcek_pub_key = NULL;
+	BIO *bio_mem = NULL;
 	bool ret = false;
 
-	if (!read_pem_into_x509(ark_pem_path, &x509_ark))
+	bio_mem = BIO_new(BIO_s_mem());
+	if (!bio_mem) {
 		goto err;
-	if (!read_pem_into_x509(ask_pem_path, &x509_ask))
+	}
+	BIO_puts(bio_mem, ask_pem);
+	x509_ask = PEM_read_bio_X509(bio_mem, NULL, NULL, NULL);
+	if (!x509_ask) {
 		goto err;
-	if (!read_pem_into_x509(vcek_pem_path, &x509_vcek))
+	}
+	BIO_reset(bio_mem);
+	BIO_puts(bio_mem, ark_pem);
+	x509_ark = PEM_read_bio_X509(bio_mem, NULL, NULL, NULL);
+	if (!x509_ark) {
 		goto err;
+	}
+	char *vcek_ptr = evidence->snp.vcek;
+	x509_vcek = d2i_X509(NULL, (const unsigned char **)&(vcek_ptr), evidence->snp.vcek_len);
+	if (!x509_vcek) {
+		goto err;
+	}
 
 	/* Extract the VCEK public key */
 	vcek_pub_key = X509_get_pubkey(x509_vcek);
@@ -204,37 +113,8 @@ err:
 	X509_free(x509_ark);
 	X509_free(x509_ask);
 	X509_free(x509_vcek);
+	BIO_free(bio_mem);
 	EVP_PKEY_free(vcek_pub_key);
-
-	return err;
-}
-
-rats_verifier_err_t sev_snp_verify_evidence(rats_verifier_ctx_t *ctx,
-					    attestation_evidence_t *evidence, uint8_t *hash,
-					    uint32_t hash_len)
-{
-	RATS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
-
-	rats_verifier_err_t err = -RATS_VERIFIER_ERR_UNKNOWN;
-	snp_attestation_report_t *snp_report = (snp_attestation_report_t *)(evidence->snp.report);
-
-	/* Generate ARK, ASK and VCEK pem files */
-	int ret = generate_vcek_pem(snp_report->chip_id, sizeof(snp_report->chip_id),
-				    &snp_report->platform_version);
-	if (ret == -1) {
-		RATS_ERR("failed to generate vcek pem\n");
-		return err;
-	}
-
-	ret = generate_ark_ask_pem();
-	if (ret == -1) {
-		RATS_ERR("failed to generate ark ask pem\n");
-		return err;
-	}
-
-	err = validate_cert_chain_vcek(snp_report, hash, hash_len);
-	if (err != RATS_VERIFIER_ERR_NONE)
-		RATS_ERR("failed to verify snp attestation report\n");
 
 	return err;
 }

--- a/verifiers/sev-snp/x509cert.c
+++ b/verifiers/sev-snp/x509cert.c
@@ -15,41 +15,81 @@
 #include "x509cert.h"
 #include "utils.h"
 
-int convert_der_to_pem(char *in_file_name, char *out_file_name)
-{
-	char cmdline_str[200] = {
-		0,
-	};
+const char ask_pem[] = "-----BEGIN CERTIFICATE-----\n"
+		       "MIIGiTCCBDigAwIBAgIDAQABMEYGCSqGSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAIC\n"
+		       "BQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMKMDAgEBMHsxFDAS\n"
+		       "BgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEg\n"
+		       "Q2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZp\n"
+		       "Y2VzMRIwEAYDVQQDDAlBUkstTWlsYW4wHhcNMjAxMDIyMTgyNDIwWhcNNDUxMDIy\n"
+		       "MTgyNDIwWjB7MRQwEgYDVQQLDAtFbmdpbmVlcmluZzELMAkGA1UEBhMCVVMxFDAS\n"
+		       "BgNVBAcMC1NhbnRhIENsYXJhMQswCQYDVQQIDAJDQTEfMB0GA1UECgwWQWR2YW5j\n"
+		       "ZWQgTWljcm8gRGV2aWNlczESMBAGA1UEAwwJU0VWLU1pbGFuMIICIjANBgkqhkiG\n"
+		       "9w0BAQEFAAOCAg8AMIICCgKCAgEAnU2drrNTfbhNQIllf+W2y+ROCbSzId1aKZft\n"
+		       "2T9zjZQOzjGccl17i1mIKWl7NTcB0VYXt3JxZSzOZjsjLNVAEN2MGj9TiedL+Qew\n"
+		       "KZX0JmQEuYjm+WKksLtxgdLp9E7EZNwNDqV1r0qRP5tB8OWkyQbIdLeu4aCz7j/S\n"
+		       "l1FkBytev9sbFGzt7cwnjzi9m7noqsk+uRVBp3+In35QPdcj8YflEmnHBNvuUDJh\n"
+		       "LCJMW8KOjP6++Phbs3iCitJcANEtW4qTNFoKW3CHlbcSCjTM8KsNbUx3A8ek5EVL\n"
+		       "jZWH1pt9E3TfpR6XyfQKnY6kl5aEIPwdW3eFYaqCFPrIo9pQT6WuDSP4JCYJbZne\n"
+		       "KKIbZjzXkJt3NQG32EukYImBb9SCkm9+fS5LZFg9ojzubMX3+NkBoSXI7OPvnHMx\n"
+		       "jup9mw5se6QUV7GqpCA2TNypolmuQ+cAaxV7JqHE8dl9pWf+Y3arb+9iiFCwFt4l\n"
+		       "AlJw5D0CTRTC1Y5YWFDBCrA/vGnmTnqG8C+jjUAS7cjjR8q4OPhyDmJRPnaC/ZG5\n"
+		       "uP0K0z6GoO/3uen9wqshCuHegLTpOeHEJRKrQFr4PVIwVOB0+ebO5FgoyOw43nyF\n"
+		       "D5UKBDxEB4BKo/0uAiKHLRvvgLbORbU8KARIs1EoqEjmF8UtrmQWV2hUjwzqwvHF\n"
+		       "ei8rPxMCAwEAAaOBozCBoDAdBgNVHQ4EFgQUO8ZuGCrD/T1iZEib47dHLLT8v/gw\n"
+		       "HwYDVR0jBBgwFoAUhawa0UP3yKxV1MUdQUir1XhK1FMwEgYDVR0TAQH/BAgwBgEB\n"
+		       "/wIBADAOBgNVHQ8BAf8EBAMCAQQwOgYDVR0fBDMwMTAvoC2gK4YpaHR0cHM6Ly9r\n"
+		       "ZHNpbnRmLmFtZC5jb20vdmNlay92MS9NaWxhbi9jcmwwRgYJKoZIhvcNAQEKMDmg\n"
+		       "DzANBglghkgBZQMEAgIFAKEcMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgIFAKID\n"
+		       "AgEwowMCAQEDggIBAIgeUQScAf3lDYqgWU1VtlDbmIN8S2dC5kmQzsZ/HtAjQnLE\n"
+		       "PI1jh3gJbLxL6gf3K8jxctzOWnkYcbdfMOOr28KT35IaAR20rekKRFptTHhe+DFr\n"
+		       "3AFzZLDD7cWK29/GpPitPJDKCvI7A4Ug06rk7J0zBe1fz/qe4i2/F12rvfwCGYhc\n"
+		       "RxPy7QF3q8fR6GCJdB1UQ5SlwCjFxD4uezURztIlIAjMkt7DFvKRh+2zK+5plVGG\n"
+		       "FsjDJtMz2ud9y0pvOE4j3dH5IW9jGxaSGStqNrabnnpF236ETr1/a43b8FFKL5QN\n"
+		       "mt8Vr9xnXRpznqCRvqjr+kVrb6dlfuTlliXeQTMlBoRWFJORL8AcBJxGZ4K2mXft\n"
+		       "l1jU5TLeh5KXL9NW7a/qAOIUs2FiOhqrtzAhJRg9Ij8QkQ9Pk+cKGzw6El3T3kFr\n"
+		       "Eg6zkxmvMuabZOsdKfRkWfhH2ZKcTlDfmH1H0zq0Q2bG3uvaVdiCtFY1LlWyB38J\n"
+		       "S2fNsR/Py6t5brEJCFNvzaDky6KeC4ion/cVgUai7zzS3bGQWzKDKU35SqNU2WkP\n"
+		       "I8xCZ00WtIiKKFnXWUQxvlKmmgZBIYPe01zD0N8atFxmWiSnfJl690B9rJpNR/fI\n"
+		       "ajxCW3Seiws6r1Zm+tCuVbMiNtpS9ThjNX4uve5thyfE2DgoxRFvY1CsoF5M\n"
+		       "-----END CERTIFICATE-----";
 
-	int count = snprintf(cmdline_str, sizeof(cmdline_str),
-			     "openssl x509 -inform der -in %s -out %s", in_file_name,
-			     out_file_name);
-	cmdline_str[count] = '\0';
-
-	if (system(cmdline_str) != 0)
-		return -1;
-
-	return 0;
-}
-
-bool read_pem_into_x509(char *file_name, X509 **x509_cert)
-{
-	FILE *pFile = NULL;
-	pFile = fopen(file_name, "re");
-	if (!pFile)
-		return false;
-
-	*x509_cert = PEM_read_X509(pFile, NULL, NULL, NULL);
-	if (!x509_cert) {
-		RATS_ERR("failed to read x509 from file: %s\n", file_name);
-		fclose(pFile);
-		return false;
-	}
-
-	fclose(pFile);
-
-	return true;
-}
+const char ark_pem[] = "-----BEGIN CERTIFICATE-----\n"
+		       "MIIGYzCCBBKgAwIBAgIDAQAAMEYGCSqGSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAIC\n"
+		       "BQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMKMDAgEBMHsxFDAS\n"
+		       "BgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEg\n"
+		       "Q2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZp\n"
+		       "Y2VzMRIwEAYDVQQDDAlBUkstTWlsYW4wHhcNMjAxMDIyMTcyMzA1WhcNNDUxMDIy\n"
+		       "MTcyMzA1WjB7MRQwEgYDVQQLDAtFbmdpbmVlcmluZzELMAkGA1UEBhMCVVMxFDAS\n"
+		       "BgNVBAcMC1NhbnRhIENsYXJhMQswCQYDVQQIDAJDQTEfMB0GA1UECgwWQWR2YW5j\n"
+		       "ZWQgTWljcm8gRGV2aWNlczESMBAGA1UEAwwJQVJLLU1pbGFuMIICIjANBgkqhkiG\n"
+		       "9w0BAQEFAAOCAg8AMIICCgKCAgEA0Ld52RJOdeiJlqK2JdsVmD7FktuotWwX1fNg\n"
+		       "W41XY9Xz1HEhSUmhLz9Cu9DHRlvgJSNxbeYYsnJfvyjx1MfU0V5tkKiU1EesNFta\n"
+		       "1kTA0szNisdYc9isqk7mXT5+KfGRbfc4V/9zRIcE8jlHN61S1ju8X93+6dxDUrG2\n"
+		       "SzxqJ4BhqyYmUDruPXJSX4vUc01P7j98MpqOS95rORdGHeI52Naz5m2B+O+vjsC0\n"
+		       "60d37jY9LFeuOP4Meri8qgfi2S5kKqg/aF6aPtuAZQVR7u3KFYXP59XmJgtcog05\n"
+		       "gmI0T/OitLhuzVvpZcLph0odh/1IPXqx3+MnjD97A7fXpqGd/y8KxX7jksTEzAOg\n"
+		       "bKAeam3lm+3yKIcTYMlsRMXPcjNbIvmsBykD//xSniusuHBkgnlENEWx1UcbQQrs\n"
+		       "+gVDkuVPhsnzIRNgYvM48Y+7LGiJYnrmE8xcrexekBxrva2V9TJQqnN3Q53kt5vi\n"
+		       "Qi3+gCfmkwC0F0tirIZbLkXPrPwzZ0M9eNxhIySb2npJfgnqz55I0u33wh4r0ZNQ\n"
+		       "eTGfw03MBUtyuzGesGkcw+loqMaq1qR4tjGbPYxCvpCq7+OgpCCoMNit2uLo9M18\n"
+		       "fHz10lOMT8nWAUvRZFzteXCm+7PHdYPlmQwUw3LvenJ/ILXoQPHfbkH0CyPfhl1j\n"
+		       "WhJFZasCAwEAAaN+MHwwDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBSFrBrRQ/fI\n"
+		       "rFXUxR1BSKvVeErUUzAPBgNVHRMBAf8EBTADAQH/MDoGA1UdHwQzMDEwL6AtoCuG\n"
+		       "KWh0dHBzOi8va2RzaW50Zi5hbWQuY29tL3ZjZWsvdjEvTWlsYW4vY3JsMEYGCSqG\n"
+		       "SIb3DQEBCjA5oA8wDQYJYIZIAWUDBAICBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZI\n"
+		       "AWUDBAICBQCiAwIBMKMDAgEBA4ICAQC6m0kDp6zv4Ojfgy+zleehsx6ol0ocgVel\n"
+		       "ETobpx+EuCsqVFRPK1jZ1sp/lyd9+0fQ0r66n7kagRk4Ca39g66WGTJMeJdqYriw\n"
+		       "STjjDCKVPSesWXYPVAyDhmP5n2v+BYipZWhpvqpaiO+EGK5IBP+578QeW/sSokrK\n"
+		       "dHaLAxG2LhZxj9aF73fqC7OAJZ5aPonw4RE299FVarh1Tx2eT3wSgkDgutCTB1Yq\n"
+		       "zT5DuwvAe+co2CIVIzMDamYuSFjPN0BCgojl7V+bTou7dMsqIu/TW/rPCX9/EUcp\n"
+		       "KGKqPQ3P+N9r1hjEFY1plBg93t53OOo49GNI+V1zvXPLI6xIFVsh+mto2RtgEX/e\n"
+		       "pmMKTNN6psW88qg7c1hTWtN6MbRuQ0vm+O+/2tKBF2h8THb94OvvHHoFDpbCELlq\n"
+		       "HnIYhxy0YKXGyaW1NjfULxrrmxVW4wcn5E8GddmvNa6yYm8scJagEi13mhGu4Jqh\n"
+		       "3QU3sf8iUSUr09xQDwHtOQUVIqx4maBZPBtSMf+qUDtjXSSq8lfWcd8bLr9mdsUn\n"
+		       "JZJ0+tuPMKmBnSH860llKk+VpVQsgqbzDIvOLvD6W1Umq25boxCYJ+TuBoa4s+HH\n"
+		       "CViAvgT9kf/rBq1d+ivj6skkHxuzcxbk1xv6ZGxrteJxVH7KlX7YRdZ6eARKwLe4\n"
+		       "AFZEAwoKCQ==\n"
+		       "-----END CERTIFICATE-----";
 
 bool x509_validate_signature(X509 *child_cert, X509 *intermediate_cert, X509 *parent_cert)
 {

--- a/verifiers/sev-snp/x509cert.h
+++ b/verifiers/sev-snp/x509cert.h
@@ -9,8 +9,9 @@
 
 #include <stdbool.h>
 
-int convert_der_to_pem(char *in_file_name, char *out_file_name);
-bool read_pem_into_x509(char *file_name, X509 **x509_cert);
+extern const char ask_pem[];
+extern const char ark_pem[];
+
 bool x509_validate_signature(X509 *child_cert, X509 *intermediate_cert, X509 *parent_cert);
 
 #endif /* _X509CERT_H */

--- a/verifiers/sev/CMakeLists.txt
+++ b/verifiers/sev/CMakeLists.txt
@@ -9,7 +9,7 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
 include_directories(${INCLUDE_DIRS})
 
 # Set dependency library directory
-set(LIBRARY_DIRS ${CMAKE_BINARY_DIR}/src
+set(LIBRARY_DIRS ${CMAKE_BINARY_DIR}
                  ${RATS_INSTALL_LIB_PATH}
                  )
 link_directories(${LIBRARY_DIRS})
@@ -27,7 +27,7 @@ set(SOURCES cleanup.c
 
 # Generate library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
-target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto)
+target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto curl)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
 # Install library

--- a/verifiers/sev/pre_init.c
+++ b/verifiers/sev/pre_init.c
@@ -13,11 +13,5 @@ rats_verifier_err_t sev_verifier_pre_init(void)
 
 	rats_verifier_err_t err = RATS_VERIFIER_ERR_NONE;
 
-	char *cmdline_str = "which wget 1> /dev/null 2> /dev/null";
-	if (system(cmdline_str) != 0) {
-		RATS_ERR("please install wget for sev(-es) verify\n");
-		err = -RATS_VERIFIER_ERR_NO_TOOL;
-	}
-
 	return err;
 }

--- a/verifiers/sev/sev_utils.c
+++ b/verifiers/sev/sev_utils.c
@@ -8,6 +8,18 @@
 #include <stddef.h>
 #include <librats/log.h>
 #include "../sev-snp/utils.c"
+#include "sev_utils.h"
+#include <curl/curl.h>
+
+int get_file_size(char *name)
+{
+	struct stat statbuf;
+
+	if (stat(name, &statbuf) == 0)
+		return statbuf.st_size;
+
+	return 0;
+}
 
 int read_file(const char *filename, void *buffer, size_t len)
 {
@@ -27,4 +39,59 @@ int read_file(const char *filename, void *buffer, size_t len)
 
 	fclose(fp);
 	return count;
+}
+
+size_t curl_writefunc_callback(void *ptr, size_t size, size_t nmemb, FILE *stream)
+{
+	size_t written = fwrite(ptr, size, nmemb, stream);
+	return written;
+}
+
+int download_from_url(const char *url, const char *file_path)
+{
+	CURL *curl = NULL;
+	FILE *fp = NULL;
+	int ret = -1;
+	CURLcode curl_ret = CURLE_OK;
+
+	fp = fopen(file_path, "wb");
+	if (fp == NULL) {
+		return -1;
+	}
+
+	curl = curl_easy_init();
+	if (!curl) {
+		RATS_ERR("failed to init curl.");
+		goto err;
+	}
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_writefunc_callback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+	for (int i = 0; i < CURL_RETRY_TIMES; i++) {
+		if ((curl_ret = curl_easy_perform(curl)) == CURLE_OK) {
+			break;
+		}
+		RATS_DEBUG("failed to download ask_ark, try again.");
+	}
+
+	if (curl_ret != CURLE_OK) {
+		RATS_ERR("failed to download ask_ark after %d retries,%s\n", CURL_RETRY_TIMES,
+			 curl_easy_strerror(curl_ret));
+		goto err;
+	}
+	ret = 0;
+
+err:
+	if (curl) {
+		curl_easy_cleanup(curl);
+	}
+	if (fp) {
+		fclose(fp);
+	}
+	if (ret == -1) {
+		remove(file_path);
+	}
+	return ret;
 }

--- a/verifiers/sev/sev_utils.h
+++ b/verifiers/sev/sev_utils.h
@@ -29,6 +29,10 @@
 #define ASK_ARK_ROME_SITE   ASK_ARK_PATH_SITE ASK_ARK_ROME_FILE
 #define ASK_ARK_MILAN_SITE  ASK_ARK_PATH_SITE ASK_ARK_MILAN_FILE
 
+#define CURL_RETRY_TIMES 5
+
+int get_file_size(char *name);
 int read_file(const char *filename, void *buffer, size_t len);
+int download_from_url(const char *url, const char *file_path);
 
 #endif /* _SEV_UTILS_H */


### PR DESCRIPTION
1. Remove system(), using libcurl instead of "wget", etc.
2. Embed vcek.der into sev-snp evidence instead of acquired by the verifier.
3. Bugfix: replace rats_verifier_err_t with rats_attester_err_t in csv attester.