### PR TITLE
librats: refine verifying quote support in occlum mode

### DIFF
--- a/verifiers/sgx-ecdsa-qve/CMakeLists.txt
+++ b/verifiers/sgx-ecdsa-qve/CMakeLists.txt
@@ -17,11 +17,6 @@ if(OCCLUM)
 endif()
 link_directories(${LIBRARY_DIRS})
 
-# Set extra link library
-if(OCCLUM)
-    set(EXTRA_LINK_LIBRARY dcap_quote pthread m)
-endif()
-
 # Set source file
 if(SGX)
     set(SOURCES init.c

--- a/verifiers/sgx-ecdsa/CMakeLists.txt
+++ b/verifiers/sgx-ecdsa/CMakeLists.txt
@@ -18,7 +18,6 @@ set(LIBRARY_DIRS ${CMAKE_BINARY_DIR}
 # Set extra link library
 if(OCCLUM)
     list(APPEND LIBRARY_DIRS ${SGXSDK_INSTALL_LIB_PATH})
-    set(EXTRA_LINK_LIBRARY dcap_quote pthread m)
 else()
     set(EXTRA_LINK_LIBRARY sgx_dcap_quoteverify)
 endif()

--- a/verifiers/sgx-ecdsa/verify_evidence.c
+++ b/verifiers/sgx-ecdsa/verify_evidence.c
@@ -22,7 +22,6 @@
 #include <sys/ioctl.h>
 #include <errno.h>
 #include "quote_verification.h"
-#include "dcap_quote.h"
 #else
 #include <sgx_dcap_quoteverify.h>
 #include <sgx_dcap_ql_wrapper.h>
@@ -137,63 +136,79 @@ rats_verifier_err_t sgx_ecdsa_verify_evidence(rats_verifier_ctx_t *ctx,
 
 	rats_verifier_err_t err = RATS_VERIFIER_ERR_NONE;
 #ifdef OCCLUM
-	void *handle = dcap_quote_open();
-
-	uint32_t supplemental_size = dcap_get_supplemental_data_size(handle);
-	uint8_t *p_supplemental_buffer = (uint8_t *)calloc(supplemental_size, sizeof(uint8_t));
-	if (NULL == p_supplemental_buffer) {
-		RATS_ERR("Couldn't allocate supplemental buffer\n");
-	}
-
+	uint32_t supplemental_data_size = 0;
+	uint8_t *p_supplemental_data = NULL;
 	sgx_ql_qv_result_t quote_verification_result = SGX_QL_QV_RESULT_UNSPECIFIED;
 	uint32_t collateral_expiration_status = 1;
-	uint32_t ret = dcap_verify_quote(handle, evidence->ecdsa.quote, evidence->ecdsa.quote_len,
-					 &collateral_expiration_status, &quote_verification_result,
-					 supplemental_size, p_supplemental_buffer);
-	if (ret != 0) {
-		RATS_ERR("Error in dcap_verify_quote.\n");
-		err = RATS_VERIFIER_ERR_UNKNOWN;
+
+	int sgx_fd = open("/dev/sgx", O_RDONLY);
+	if (sgx_fd < 0) {
+		RATS_ERR("failed to open /dev/sgx\n");
+		return -RATS_VERIFIER_ERR_INVALID;
 	}
 
-	if (collateral_expiration_status != 0) {
-		RATS_WARN("The verification collateral has expired!\n");
-		err = RATS_VERIFIER_ERR_INVALID;
+	if (ioctl(sgx_fd, SGXIOC_GET_DCAP_SUPPLEMENTAL_SIZE, &supplemental_data_size) < 0) {
+		RATS_ERR("failed to ioctl get supplemental data size: %s\n", strerror(errno));
+		close(sgx_fd);
+		return -RATS_VERIFIER_ERR_INVALID;
 	}
 
-	RATS_DEBUG("called dcap_verify_quote.\n");
+	p_supplemental_data = (uint8_t *)malloc(supplemental_data_size);
+	if (!p_supplemental_data) {
+		close(sgx_fd);
+		return -RATS_VERIFIER_ERR_NO_MEM;
+	}
+
+	memset(p_supplemental_data, 0, supplemental_data_size);
+
+	sgxioc_ver_dcap_quote_arg_t ver_quote_arg = {
+		.quote_buf = evidence->ecdsa.quote,
+		.quote_size = evidence->ecdsa.quote_len,
+		.collateral_expiration_status = &collateral_expiration_status,
+		.quote_verification_result = &quote_verification_result,
+		.supplemental_data_size = supplemental_data_size,
+		.supplemental_data = p_supplemental_data
+	};
+
+	if (ioctl(sgx_fd, SGXIOC_VER_DCAP_QUOTE, &ver_quote_arg) < 0) {
+		RATS_ERR("failed to ioctl verify quote: %s\n", strerror(errno));
+		close(sgx_fd);
+		return -RATS_VERIFIER_ERR_INVALID;
+	}
+
+	close(sgx_fd);
+
+	/* Check verification result */
 	switch (quote_verification_result) {
 	case SGX_QL_QV_RESULT_OK:
-		RATS_INFO("Succeed to verify the quote!\n");
+		RATS_INFO("verification completed successfully.\n");
+		err = RATS_VERIFIER_ERR_NONE;
 		break;
 	case SGX_QL_QV_RESULT_CONFIG_NEEDED:
 	case SGX_QL_QV_RESULT_OUT_OF_DATE:
 	case SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED:
 	case SGX_QL_QV_RESULT_SW_HARDENING_NEEDED:
 	case SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED:
-		RATS_WARN("WARN: App: Verification completed with Non-terminal result: %x\n",
+		RATS_WARN("verification completed with Non-terminal result: %x\n",
 			  quote_verification_result);
+		err = SGX_ECDSA_VERIFIER_ERR_CODE((int)quote_verification_result);
 		break;
 	case SGX_QL_QV_RESULT_INVALID_SIGNATURE:
 	case SGX_QL_QV_RESULT_REVOKED:
 	case SGX_QL_QV_RESULT_UNSPECIFIED:
 	default:
-		RATS_ERR("\tError: App: Verification completed with Terminal result: %x\n",
+		RATS_ERR("verification completed with Terminal result: %x\n",
 			 quote_verification_result);
+		err = SGX_ECDSA_VERIFIER_ERR_CODE((int)quote_verification_result);
+		break;
 	}
-
-	if (p_supplemental_buffer) {
-		free(p_supplemental_buffer);
-		p_supplemental_buffer = NULL;
-	}
-
-	dcap_quote_close(handle);
-	return err;
 #elif defined(SGX)
 	sgx_ecdsa_ctx_t *ecdsa_ctx = (sgx_ecdsa_ctx_t *)ctx->verifier_private;
 	sgx_enclave_id_t eid = (sgx_enclave_id_t)ecdsa_ctx->eid;
-	sgx_status_t sgx_ret = ocall_ecdsa_verify_evidence(&err, ctx, eid, ctx->opts->name, evidence,
-				    sizeof(attestation_evidence_t), hash, hash_len);
-	if (sgx_ret != SGX_SUCCESS || err != RATS_VERIFIER_ERR_NONE) 
+	sgx_status_t sgx_ret = ocall_ecdsa_verify_evidence(&err, ctx, eid, ctx->opts->name,
+							   evidence, sizeof(attestation_evidence_t),
+							   hash, hash_len);
+	if (sgx_ret != SGX_SUCCESS || err != RATS_VERIFIER_ERR_NONE)
 		RATS_ERR("failed to verify ecdsa, %04x, %04x\n", sgx_ret, err);
 #else
 	err = ecdsa_verify_evidence(ctx, ctx->opts->name, evidence, sizeof(attestation_evidence_t),


### PR DESCRIPTION
1. refine verifying quote support code
2. format the verify_evidence.c

Fixes: #33

Signed-off-by: Liang Yang <liang3.yang@intel.com>