### PR TITLE
librats: rename ocall functions to rats_ocall ones

### DIFF
--- a/attesters/sgx-ecdsa/collect_evidence.c
+++ b/attesters/sgx-ecdsa/collect_evidence.c
@@ -34,7 +34,7 @@ sgx_status_t sgx_generate_evidence(const uint8_t *hash, sgx_report_t *app_report
 
 	sgx_target_info_t qe_target_info;
 	memset(&qe_target_info, 0, sizeof(sgx_target_info_t));
-	sgx_status_t sgx_error = ocall_get_target_info(&qe_target_info);
+	sgx_status_t sgx_error = rats_ocall_get_target_info(&qe_target_info);
 	if (SGX_SUCCESS != sgx_error)
 		return sgx_error;
 
@@ -111,13 +111,13 @@ rats_attester_err_t sgx_ecdsa_collect_evidence(rats_attester_ctx_t *ctx,
 	rats_attester_err_t qe3_ret;
 	int sgx_status;
 	uint32_t quote_size = 0;
-	sgx_status = ocall_qe_get_quote_size(&qe3_ret, &quote_size);
+	sgx_status = rats_ocall_qe_get_quote_size(&qe3_ret, &quote_size);
 	if (SGX_SUCCESS != sgx_status || RATS_ATTESTER_ERR_NONE != qe3_ret) {
 		RATS_ERR("sgx_qe_get_quote_size(): 0x%04x, 0x%04x\n", sgx_status, qe3_ret);
 		return SGX_ECDSA_ATTESTER_ERR_CODE((int)qe3_ret);
 	}
 
-	sgx_status = ocall_qe_get_quote(&qe3_ret, &app_report, quote_size, evidence->ecdsa.quote);
+	sgx_status = rats_ocall_qe_get_quote(&qe3_ret, &app_report, quote_size, evidence->ecdsa.quote);
 	if (SGX_SUCCESS != sgx_status || RATS_ATTESTER_ERR_NONE != qe3_ret) {
 		RATS_ERR("sgx_qe_get_quote(): 0x%04x, 0x%04x\n", sgx_status, qe3_ret);
 		return SGX_ECDSA_ATTESTER_ERR_CODE((int)qe3_ret);

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -89,14 +89,14 @@ static inline void __cpuidex(int a[4], int b, int c)
 {
 	a[0] = b;
 	a[2] = c;
-	ocall_cpuid(&a[0], &a[1], &a[2], &a[3]);
+	rats_ocall_cpuid(&a[0], &a[1], &a[2], &a[3]);
 }
 
 static bool is_legacy_oot_kernel_driver(void)
 {
 	bool retval;
 
-	ocall_is_sgx_dev(&retval, "/dev/isgx");
+	rats_ocall_is_sgx_dev(&retval, "/dev/isgx");
 
 	return retval;
 }
@@ -108,7 +108,7 @@ static bool is_dcap_1_9_oot_kernel_driver(void)
 {
 	bool retval;
 
-	ocall_is_sgx_dev(&retval, "/dev/sgx/enclave");
+	rats_ocall_is_sgx_dev(&retval, "/dev/sgx/enclave");
 
 	return retval;
 }
@@ -120,7 +120,7 @@ static bool is_in_tree_kernel_driver(void)
 {
 	bool retval;
 
-	ocall_is_sgx_dev(&retval, "/dev/sgx_enclave");
+	rats_ocall_is_sgx_dev(&retval, "/dev/sgx_enclave");
 
 	return retval;
 }

--- a/core/rats_common.c
+++ b/core/rats_common.c
@@ -39,7 +39,7 @@ rats_log_level_t rats_global_log_level = RATS_LOG_LEVEL_DEFAULT;
 #ifdef SGX
 void rats_exit(void)
 {
-    ocall_exit();
+    rats_ocall_exit();
 }
 
 rats_log_level_t rats_loglevel_getenv(const char *name)
@@ -53,7 +53,7 @@ rats_log_level_t rats_loglevel_getenv(const char *name)
         return -1;
     }
 
-    ocall_getenv(name, log_level_str, log_level_len);
+    rats_ocall_getenv(name, log_level_str, log_level_len);
     if (log_level_str) {
         if (!strcmp(log_level_str, "debug") || !strcmp(log_level_str, "DEBUG")) {
             free(log_level_str);
@@ -141,7 +141,7 @@ rats_verifier_err_t rats_verifier_init(const char *name, __attribute__((unused))
 ssize_t rats_write(int fd, const void *buf, size_t count)
 {
     ssize_t rc;
-    int sgx_status = ocall_write(&rc, fd, buf, count);
+    int sgx_status = rats_ocall_write(&rc, fd, buf, count);
     if (SGX_SUCCESS != sgx_status) {
         RATS_ERR("sgx failed to write data, sgx status: 0x%04x\n", sgx_status);
     }
@@ -152,7 +152,7 @@ ssize_t rats_write(int fd, const void *buf, size_t count)
 ssize_t rats_read(int fd, void *buf, size_t count)
 {
     ssize_t rc;
-    int sgx_status = ocall_read(&rc, fd, buf, count);
+    int sgx_status = rats_ocall_read(&rc, fd, buf, count);
     if (SGX_SUCCESS != sgx_status) {
         RATS_ERR("sgx failed to read data, sgx status: 0x%04x\n", sgx_status);
     }
@@ -164,7 +164,7 @@ uint64_t rats_opendir(const char *name)
 {
     uint64_t dir;
 
-    int sgx_status = ocall_opendir(&dir, name);
+    int sgx_status = rats_ocall_opendir(&dir, name);
     if (sgx_status != SGX_SUCCESS) {
         RATS_ERR("sgx failed to open %s, sgx status: 0x%04x\n", name, sgx_status);
     }
@@ -181,7 +181,7 @@ int rats_readdir(uint64_t dirp, rats_dirent **ptr)
         RATS_ERR("failed to calloc memory in rats_readdir\n");
         return -1;
     }
-    ocall_readdir(&ret, dirp, *ptr);
+    rats_ocall_readdir(&ret, dirp, *ptr);
 
     return ret;
 }
@@ -189,7 +189,7 @@ int rats_readdir(uint64_t dirp, rats_dirent **ptr)
 int rats_closedir(uint64_t dir)
 {
     int ret = 0;
-    ocall_closedir(&ret, dir);
+    rats_ocall_closedir(&ret, dir);
 
     return ret;
 }

--- a/include/edl/rats_syscalls.edl
+++ b/include/edl/rats_syscalls.edl
@@ -4,20 +4,20 @@ enclave {
 	from "sgx_dummy.edl" import *;
 
 	untrusted {
-		void ocall_exit(void);
-		void ocall_cpuid([in, out] int *eax, [in, out] int *ebx, [in, out] int *ecx,
+		void rats_ocall_exit(void);
+		void rats_ocall_cpuid([in, out] int *eax, [in, out] int *ebx, [in, out] int *ecx,
 				 [in, out] int *edx);
-		void ocall_is_sgx_dev([in, out] bool *retval, [in] const char *dev);
-		void ocall_print_string([in, string] const char *str);
-		uint64_t ocall_opendir([in, string] const char *name) propagate_errno;
-		int ocall_readdir(uint64_t dirp, [out, count=1] struct ocall_dirent * entry)
+		void rats_ocall_is_sgx_dev([in, out] bool *retval, [in] const char *dev);
+		void rats_ocall_print_string([in, string] const char *str);
+		uint64_t rats_ocall_opendir([in, string] const char *name) propagate_errno;
+		int rats_ocall_readdir(uint64_t dirp, [out, count=1] struct rats_ocall_dirent * entry)
 				  propagate_errno;
-		int ocall_closedir(uint64_t dirp) propagate_errno;
-		ssize_t ocall_read(int fd, [in, out, size=count] void *buf, size_t count);
-		ssize_t ocall_write(int fd, [user_check] const void *buf, size_t count);
-		void ocall_getenv([in, string] const char *name, [out, size=len] char *value,
+		int rats_ocall_closedir(uint64_t dirp) propagate_errno;
+		ssize_t rats_ocall_read(int fd, [in, out, size=count] void *buf, size_t count);
+		ssize_t rats_ocall_write(int fd, [user_check] const void *buf, size_t count);
+		void rats_ocall_getenv([in, string] const char *name, [out, size=len] char *value,
 				  size_t len);
-		void ocall_current_time([out] double *time);
-		void ocall_low_res_time([out] int *time);
+		void rats_ocall_current_time([out] double *time);
+		void rats_ocall_low_res_time([out] int *time);
 	};
 };

--- a/include/edl/rats_syscalls.h
+++ b/include/edl/rats_syscalls.h
@@ -9,7 +9,7 @@
 
 #include <sys/types.h>
 
-struct ocall_dirent {
+struct rats_ocall_dirent {
 	u_int64_t d_ino;
 	int64_t d_off; //off_t
 	u_int16_t d_reclen;

--- a/include/edl/sgx_ecdsa.edl
+++ b/include/edl/sgx_ecdsa.edl
@@ -9,24 +9,24 @@ enclave {
 	from "sgx_dcap_tvl.edl" import *;
 
 	trusted {
-		public sgx_status_t ecall_get_target_info([out] sgx_target_info_t* target_info);
+		public sgx_status_t rats_ecall_get_target_info([out] sgx_target_info_t* target_info);
 	};
 
 	untrusted {
-		void ocall_get_target_info([out] sgx_target_info_t *qe_target_info);
+		void rats_ocall_get_target_info([out] sgx_target_info_t *qe_target_info);
 
-		rats_attester_err_t ocall_qe_get_quote_size([out] uint32_t *quote_size);
+		rats_attester_err_t rats_ocall_qe_get_quote_size([out] uint32_t *quote_size);
 
-		rats_attester_err_t ocall_qe_get_quote([in]sgx_report_t *report, uint32_t quote_size,
+		rats_attester_err_t rats_ocall_qe_get_quote([in]sgx_report_t *report, uint32_t quote_size,
                                                 [out, size=quote_size] uint8_t *quote);
 
-		rats_verifier_err_t ocall_ecdsa_verify_evidence([user_check] rats_verifier_ctx_t *ctx,
+		rats_verifier_err_t rats_ocall_ecdsa_verify_evidence([user_check] rats_verifier_ctx_t *ctx,
                                                                 sgx_enclave_id_t enclave_id,
                                                                 [in, string] const char *name,
                                                                 [in, size=evidence_len] attestation_evidence_t *evidence,
                                                                 uint32_t evidence_len,
                                                                 [in, size=hash_len] const uint8_t *hash,
                                                                 uint32_t hash_len)
-			allow(ecall_get_target_info, sgx_tvl_verify_qve_report_and_identity);
+			allow(rats_ecall_get_target_info, sgx_tvl_verify_qve_report_and_identity);
 	};
 };

--- a/include/edl/sgx_la.edl
+++ b/include/edl/sgx_la.edl
@@ -5,7 +5,7 @@ enclave {
 	from "sgx_dummy.edl" import *;
 
 	untrusted {
-		rats_verifier_err_t ocall_la_verify_evidence([user_check] rats_verifier_ctx_t *ctx,
+		rats_verifier_err_t rats_ocall_la_verify_evidence([user_check] rats_verifier_ctx_t *ctx,
                                                              [in, size=evidence_len] attestation_evidence_t *evidence,
                                                              uint32_t evidence_len,
                                                              [in, size=hash_len] const uint8_t *hash,

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -16,7 +16,7 @@
 // clang-format on
 
 #ifdef SGX
-typedef struct ocall_dirent rats_dirent;
+typedef struct rats_ocall_dirent rats_dirent;
 #else
 typedef struct dirent rats_dirent;
 #endif

--- a/tee/sgx/trust/rats_syscalls.c
+++ b/tee/sgx/trust/rats_syscalls.c
@@ -17,19 +17,19 @@ void printf(const char *fmt, ...)
 	va_start(ap, fmt);
 	vsnprintf(buf, BUFSIZ, fmt, ap);
 	va_end(ap);
-	ocall_print_string(buf);
+	rats_ocall_print_string(buf);
 }
 
 double current_time(void)
 {
 	double curr;
-	ocall_current_time(&curr);
+	rats_ocall_current_time(&curr);
 	return curr;
 }
 
 int LowResTimer(void)
 {
 	int time;
-	ocall_low_res_time(&time);
+	rats_ocall_low_res_time(&time);
 	return time;
 }

--- a/tee/sgx/untrust/rats_syscalls_ocall.c
+++ b/tee/sgx/untrust/rats_syscalls_ocall.c
@@ -19,12 +19,12 @@
 #include "rats_syscalls.h"
 #include "cpu.h"
 
-void ocall_exit(void)
+void rats_ocall_exit(void)
 {
 	exit(EXIT_FAILURE);
 }
 
-void ocall_print_string(const char *str)
+void rats_ocall_print_string(const char *str)
 {
 	/* Proxy/Bridge will check the length and null-terminate
 	 * the input string to prevent buffer overflow.
@@ -33,13 +33,13 @@ void ocall_print_string(const char *str)
 }
 
 /* Copy from openenclave */
-uint64_t ocall_opendir(const char *name)
+uint64_t rats_ocall_opendir(const char *name)
 {
 	return (uint64_t)opendir(name);
 }
 
 /* Copy from openenclave */
-int ocall_readdir(uint64_t dirp, struct ocall_dirent *entry)
+int rats_ocall_readdir(uint64_t dirp, struct rats_ocall_dirent *entry)
 {
 	int ret = -1;
 	struct dirent *ent;
@@ -89,24 +89,24 @@ done:
 }
 
 /* Copy from openenclave */
-int ocall_closedir(uint64_t dirp)
+int rats_ocall_closedir(uint64_t dirp)
 {
 	errno = 0;
 
 	return closedir((DIR *)dirp);
 }
 
-ssize_t ocall_read(int fd, void *buf, size_t count)
+ssize_t rats_ocall_read(int fd, void *buf, size_t count)
 {
 	return read(fd, buf, count);
 }
 
-ssize_t ocall_write(int fd, const void *buf, size_t count)
+ssize_t rats_ocall_write(int fd, const void *buf, size_t count)
 {
 	return write(fd, buf, count);
 }
 
-void ocall_getenv(const char *name, char *value, size_t len)
+void rats_ocall_getenv(const char *name, char *value, size_t len)
 {
 	memset(value, 0, len);
 
@@ -126,7 +126,7 @@ static double current_time(void)
 	return (double)((1000000.0f * (double)tv.tv_sec + (double)tv.tv_usec) / 1000000.0f);
 }
 
-void ocall_current_time(double *time)
+void rats_ocall_current_time(double *time)
 {
 	if (!time)
 		return;
@@ -136,7 +136,7 @@ void ocall_current_time(double *time)
 	return;
 }
 
-void ocall_low_res_time(int *time)
+void rats_ocall_low_res_time(int *time)
 {
 	if (!time)
 		return;
@@ -147,7 +147,7 @@ void ocall_low_res_time(int *time)
 	*time = (int)tv.tv_sec;
 }
 
-void ocall_cpuid(int *eax, int *ebx, int *ecx, int *edx)
+void rats_ocall_cpuid(int *eax, int *ebx, int *ecx, int *edx)
 {
 #if defined(__x86_64__)
 	__asm__ volatile("cpuid"
@@ -163,7 +163,7 @@ void ocall_cpuid(int *eax, int *ebx, int *ecx, int *edx)
 #endif
 }
 
-void ocall_is_sgx_dev(bool *retval, const char *dev)
+void rats_ocall_is_sgx_dev(bool *retval, const char *dev)
 {
 	struct stat st;
 

--- a/tee/sgx/untrust/sgx_ecdsa_ocall.c
+++ b/tee/sgx/untrust/sgx_ecdsa_ocall.c
@@ -22,14 +22,14 @@ static void get_random_nonce(uint8_t *nonce, uint32_t size)
 		nonce[i] = (uint8_t)((rand() % 255) + 1);
 }
 
-void ocall_get_target_info(sgx_target_info_t *qe_target_info)
+void rats_ocall_get_target_info(sgx_target_info_t *qe_target_info)
 {
 	int qe3_ret = sgx_qe_get_target_info(qe_target_info);
 	if (SGX_QL_SUCCESS != qe3_ret)
 		RATS_ERR("sgx_qe_get_target_info() with error code 0x%04x\n", qe3_ret);
 }
 
-rats_attester_err_t ocall_qe_get_quote_size(uint32_t *quote_size)
+rats_attester_err_t rats_ocall_qe_get_quote_size(uint32_t *quote_size)
 {
 	quote3_error_t qe3_ret = sgx_qe_get_quote_size(quote_size);
 	if (SGX_QL_SUCCESS != qe3_ret) {
@@ -40,7 +40,7 @@ rats_attester_err_t ocall_qe_get_quote_size(uint32_t *quote_size)
 	return RATS_ATTESTER_ERR_NONE;
 }
 
-rats_attester_err_t ocall_qe_get_quote(sgx_report_t *report, uint32_t quote_size, uint8_t *quote)
+rats_attester_err_t rats_ocall_qe_get_quote(sgx_report_t *report, uint32_t quote_size, uint8_t *quote)
 {
 	quote3_error_t qe3_ret = sgx_qe_get_quote(report, quote_size, quote);
 	if (SGX_QL_SUCCESS != qe3_ret) {
@@ -51,7 +51,7 @@ rats_attester_err_t ocall_qe_get_quote(sgx_report_t *report, uint32_t quote_size
 	return RATS_ATTESTER_ERR_NONE;
 }
 
-rats_verifier_err_t ocall_ecdsa_verify_evidence(__attribute__((unused)) rats_verifier_ctx_t *ctx,
+rats_verifier_err_t rats_ocall_ecdsa_verify_evidence(__attribute__((unused)) rats_verifier_ctx_t *ctx,
 						sgx_enclave_id_t enclave_id, const char *name,
 						attestation_evidence_t *evidence,
 						__attribute__((unused)) uint32_t evidence_len,

--- a/tee/sgx/untrust/sgx_la_ocall.c
+++ b/tee/sgx/untrust/sgx_la_ocall.c
@@ -13,7 +13,7 @@
 #include "sgx_quote_3.h"
 #include "sgx_dcap_ql_wrapper.h"
 
-rats_verifier_err_t ocall_la_verify_evidence(rats_verifier_ctx_t *ctx,
+rats_verifier_err_t rats_ocall_la_verify_evidence(rats_verifier_ctx_t *ctx,
 					     attestation_evidence_t *evidence,
 					     __attribute__((unused)) uint32_t evidence_len,
 					     const uint8_t *hash, uint32_t hash_len)

--- a/verifiers/sgx-ecdsa/verify_evidence.c
+++ b/verifiers/sgx-ecdsa/verify_evidence.c
@@ -207,7 +207,7 @@ rats_verifier_err_t sgx_ecdsa_verify_evidence(rats_verifier_ctx_t *ctx,
 #elif defined(SGX)
 	sgx_ecdsa_ctx_t *ecdsa_ctx = (sgx_ecdsa_ctx_t *)ctx->verifier_private;
 	sgx_enclave_id_t eid = (sgx_enclave_id_t)ecdsa_ctx->eid;
-	sgx_status_t sgx_ret = ocall_ecdsa_verify_evidence(&err, ctx, eid, ctx->opts->name,
+	sgx_status_t sgx_ret = rats_ocall_ecdsa_verify_evidence(&err, ctx, eid, ctx->opts->name,
 							   evidence, sizeof(attestation_evidence_t),
 							   hash, hash_len);
 	if (sgx_ret != SGX_SUCCESS || err != RATS_VERIFIER_ERR_NONE)

--- a/verifiers/sgx-la/verify_evidence.c
+++ b/verifiers/sgx-la/verify_evidence.c
@@ -19,7 +19,7 @@ rats_verifier_err_t sgx_la_verify_evidence(rats_verifier_ctx_t *ctx,
 {
 	rats_verifier_err_t err = RATS_VERIFIER_ERR_UNKNOWN;
 
-	ocall_la_verify_evidence(&err, ctx, evidence, sizeof(attestation_evidence_t), hash,
+	rats_ocall_la_verify_evidence(&err, ctx, evidence, sizeof(attestation_evidence_t), hash,
 				 hash_len);
 
 	return err;


### PR DESCRIPTION
To avoid function redefinition error, so rename all ocall functions to
rats_ocall as prefix

Fixes: #46
Signed-off-by: Liang Yang <liang3.yang@intel.com>