### PR TITLE
librats: fix the function name mismatched of ecalls

### DIFF
--- a/tee/sgx/trust/sgx_ecdsa_ecalls.c
+++ b/tee/sgx/trust/sgx_ecdsa_ecalls.c
@@ -8,7 +8,7 @@
 #include "sgx_trts.h"
 #include "sgx_utils.h"
 
-sgx_status_t ecall_get_target_info(sgx_target_info_t *target_info)
+sgx_status_t rats_ecall_get_target_info(sgx_target_info_t *target_info)
 {
 	return sgx_self_target(target_info);
 }

--- a/tee/sgx/untrust/sgx_ecdsa_ocall.c
+++ b/tee/sgx/untrust/sgx_ecdsa_ocall.c
@@ -103,7 +103,7 @@ rats_verifier_err_t rats_ocall_ecdsa_verify_evidence(__attribute__((unused)) rat
 		memcpy(qve_report_info->nonce.rand, rand_nonce, sizeof(rand_nonce));
 
 		sgx_status_t get_target_info_ret;
-		sgx_ret = ecall_get_target_info(enclave_id, &get_target_info_ret,
+		sgx_ret = rats_ecall_get_target_info(enclave_id, &get_target_info_ret,
 						&qve_report_info->app_enclave_target_info);
 		if (sgx_ret != SGX_SUCCESS || get_target_info_ret != SGX_SUCCESS) {
 			RATS_ERR(


### PR DESCRIPTION
Signed-off-by: wangya <wangya.zs@alibaba-inc.com>