### PR TITLE
.github/workflows: add required build tools for sgx-ssl to dockerfile

### DIFF
--- a/.github/workflows/docker/Dockerfile-compilation-testing-anolis8.4
+++ b/.github/workflows/docker/Dockerfile-compilation-testing-anolis8.4
@@ -5,7 +5,7 @@ LABEL maintainer="Sinuo Liu <984354607@qq.com>"
 RUN dnf clean all && rm -r /var/cache/dnf && \
     dnf --enablerepo=PowerTools install -y git wget \
     make cmake autoconf libtool gcc gcc-c++ \
-    openssl-devel libcurl-devel yum-utils \
+    openssl-devel libcurl-devel yum-utils patch \
     python2 bzip2 perl which && \
     alternatives --set python /usr/bin/python2
 
@@ -17,6 +17,11 @@ ENV PATH         /root/.cargo/bin:$PATH
 
 ENV SGX_SDK_VERSION 2.15.1
 ENV SGX_SDK_RELEASE_NUMBER 2.15.101.1
+
+# install LVI binutils for rats-tls build
+RUN wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/as.ld.objdump.r4.tar.gz && \
+    tar -zxvf as.ld.objdump.r4.tar.gz && cp -rf external/toolset/centos8.2/* /usr/local/bin/ && \
+    rm -rf external && rm -rf as.ld.objdump.r4.tar.gz
 
 # install SGX
 RUN [ ! -f sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin ] && \


### PR DESCRIPTION
This PR is for updating the `runetest/compilation-testing-librats` image to support building sgxssl.

Signed-off-by: Kun Lai <me@imlk.top>