### PR TITLE
[DONTMERGE] librats: add dependency on SGXSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ if(RATS_BUILD_MODE STREQUAL "wasm")
 endif()
 project(librats)
 set(RATS_LIB rats_lib)
+set(RATS_SRC_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 # Software version
 file(STRINGS "VERSION" RATS_VERSION)
@@ -18,7 +19,7 @@ option(SGX_HW "Run SGX on hardware, OFF for simulation" ON)
 
 # Define build mode
 set(RATS_BUILD_MODE "host"
-    CACHE STRING "Select build mode for librats(host|occlum|sgx｜wasm)")
+    CACHE STRING "Select build mode for librats(host|occlum|sgx|wasm)")
 set(SGX_ATTESTER "ecdsa"
     CACHE STRING "Select sgx attester(ecdsa|la|null)")
 
@@ -113,6 +114,7 @@ include(CustomInstallDirs)
 include(CompilerOptions)
 if(SGX)
     include(SGXCommon)
+    include(SGXSSL)
 endif()
 
 # Set include directory
@@ -120,6 +122,7 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
 if(SGX)
     list(APPEND INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include/edl
                              ${CMAKE_CURRENT_BINARY_DIR}/tee/sgx/trust
+                             ${CMAKE_BINARY_DIR}/../external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/include
                              )
 elseif(WASM)
     list(APPEND INCLUDE_DIRS ${WASM_SRCS_DIR}/openssl/install/include)
@@ -128,6 +131,7 @@ endif()
 include_directories(${INCLUDE_DIRS})
 
 # Add third party and instance directory
+add_subdirectory(external)
 if(NOT WASM)
     add_subdirectory(attesters)
 endif()
@@ -172,6 +176,7 @@ endif()
 # Static library dependencies
 if(SGX)
     set(DEPEND_TRUSTED_LIBS rats_edl_t
+                            intel-sgx-ssl
                             attester_nullattester
                             attester_sgx_ecdsa
                             attester_sgx_la

--- a/cmake/FindLibRats.cmake
+++ b/cmake/FindLibRats.cmake
@@ -1,0 +1,16 @@
+include(CustomInstallDirs)
+include(FindPackageHandleStandardArgs)
+
+set(RATS_INCLUDE_DIR ${RATS_SRC_PATH}/src/include)
+
+# Handle the QUIETLY and REQUIRED arguments and set RATS_FOUND to TRUE if all listed variables are TRUE.
+find_package_handle_standard_args(RATS
+    DEFAULT_MSG
+    RATS_INCLUDE_DIR)
+
+if(RATS_FOUND)
+    set(RATS_INCLUDES ${RATS_INCLUDE_DIR})
+else()
+    set(RATS_LIBRARIES)
+    set(RATS_INCLUDES)
+endif()

--- a/cmake/FindSGXSSL.cmake
+++ b/cmake/FindSGXSSL.cmake
@@ -1,0 +1,7 @@
+include(FindPackageHandleStandardArgs)
+
+set(INTEL_SGXSSL_ROOT ${RATS_SRC_PATH}/external/sgx-ssl/intel-sgx-ssl)
+set(INTEL_SGXSSL_SRC ${INTEL_SGXSSL_ROOT}/src/intel-sgx-ssl)
+set(INTEL_SGXSSL_LIB ${INTEL_SGXSSL_SRC}/Linux/package/lib64)
+set(OPENSSL_DIR ${INTEL_SGXSSL_SRC}/openssl_source)
+set(INTEL_SGXSSL_LIB_PATH ${CMAKE_BINARY_DIR}/external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/lib64)

--- a/cmake/SGXCommon.cmake
+++ b/cmake/SGXCommon.cmake
@@ -1,5 +1,6 @@
 # Reference https://github.com/xzhangxa/SGX-CMake.git
 include(CMakeParseArguments)
+include(FindSGXSSL)
 
 # Build edl to *_t.h and *_t.c.
 # Default not support mutiple edl which cause repeated definition for sgx edl common structure.
@@ -170,8 +171,8 @@ function(add_enclave_library target)
     endforeach()
     set(ENCLAVE_LINK_FLAGS "-m64 -Wall -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L${SGX_LIBRARY_PATH}")
     set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -pie")
-    set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,--whole-archive ${TLIB_LIST} -l${SGX_TRTS_LIB} -Wl,--no-whole-archive")
-    set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,--start-group -lsgx_tstdc -lsgx_pthread -lsgx_tcrypto -lsgx_tcxx -lsgx_tkey_exchange -lsgx_trts -lsgx_tservice -l${SGX_TSVC_LIB} -l${SGX_DCAP_TVL} -Wl,--end-group")
+    set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,--whole-archive ${TLIB_LIST} -l${SGX_TRTS_LIB} -lsgx_tsgxssl -Wl,--no-whole-archive")
+    set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,--start-group -lsgx_tstdc -lsgx_pthread -lsgx_tcxx -lsgx_tkey_exchange -lsgx_tcrypto -lsgx_trts -lsgx_tservice -lsgx_tsgxssl_crypto -l${SGX_TSVC_LIB} -l${SGX_DCAP_TVL} -Wl,--end-group")
     set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined")
     set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} -Wl,-pie,-eenclave_entry -Wl,--export-dynamic")
     set(ENCLAVE_LINK_FLAGS "${ENCLAVE_LINK_FLAGS} ${LDSCRIPT_FLAG}")
@@ -262,7 +263,7 @@ function(add_untrusted_library target mode)
         add_library(${target} ${mode} ${SGX_SRCS} $<TARGET_OBJECTS:${target}-edlobj>)
     endif()
 
-    set(UNTRUSTED_LINK_FLAGS "-L${SGX_LIBRARY_PATH} -l${SGX_URTS_LIB} -l${SGX_USVC_LIB} -l${SGX_DACP_QL} -l${SGX_DACP_QUOTEVERIFY} -lsgx_ukey_exchange")
+    set(UNTRUSTED_LINK_FLAGS "-L${SGX_LIBRARY_PATH} -l${SGX_URTS_LIB} -l${SGX_USVC_LIB} -l${SGX_DACP_QL} -l${SGX_DACP_QUOTEVERIFY} -lsgx_ukey_exchange -L${INTEL_SGXSSL_LIB} -lsgx_usgxssl")
 
     set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${APP_C_FLAGS})
     target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${APP_INCLUDES})
@@ -302,7 +303,7 @@ function(add_untrusted_executable target)
         set (ULIB_LIST "${ULIB_LIST} ${ULIB}")
     endforeach()
 
-    set(UNTRUSTED_LINK_FLAGS "-L${SGX_LIBRARY_PATH} ${ULIB_LIST} -l${SGX_URTS_LIB} -l${SGX_USVC_LIB} -l${SGX_DACP_QL} -l${SGX_DACP_QUOTEVERIFY} -lsgx_ukey_exchange")
+    set(UNTRUSTED_LINK_FLAGS "-L${SGX_LIBRARY_PATH} ${ULIB_LIST} -l${SGX_URTS_LIB} -l${SGX_USVC_LIB} -l${SGX_DACP_QL} -l${SGX_DACP_QUOTEVERIFY} -lsgx_ukey_exchange -L${INTEL_SGXSSL_LIB} -lsgx_usgxssl")
 
     set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${APP_C_FLAGS})
     target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${APP_INCLUDES})

--- a/cmake/SGXSSL.cmake
+++ b/cmake/SGXSSL.cmake
@@ -1,0 +1,106 @@
+# Project name
+if(SGX)
+    project(intel-sgx-ssl)
+endif()
+
+include(ExternalProject)
+include(FindSGXSSL)
+
+# Patch
+set(SGX_SSL_PATCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/sgx-ssl")
+set(_patch_script "${SGX_SSL_PATCH_DIR}/patch_script.sh")
+file(WRITE "${_patch_script}"
+"#!/bin/sh
+cd ${INTEL_SGXSSL_SRC}/
+if [ ! -e  Linux/sgx/libsgx_usgxssl/uunistd.cpp ]; then
+        patch -p1 < ${SGX_SSL_PATCH_DIR}/patch/0001-add-ssl-library-enclave-support.patch;
+fi;
+")
+
+set(_patch_cmake "${SGX_SSL_PATCH_DIR}/patch.cmake")
+file(WRITE "${_patch_cmake}"
+"execute_process(COMMAND sh ${_patch_script} WORKING_DIRECTORY ${SGX_SSL_PATCH_DIR} RESULT_VARIABLE result)
+if(result AND NOT result EQUAL 0)
+    message(FATAL_ERROR \"FAILED: \${result}\")
+endif()
+"
+)
+
+# Configure
+set(_configure_script "${SGX_SSL_PATCH_DIR}/download_script.sh")
+file(WRITE "${_configure_script}"
+"#!/bin/sh
+if [ ! -e ${OPENSSL_DIR}/openssl-1.1.1*.tar.gz ]; then
+        wget --no-check-certificate https://www.openssl.org/source/openssl-1.1.1k.tar.gz -P ${OPENSSL_DIR};
+fi;
+")
+
+set(_configure_cmake "${SGX_SSL_PATCH_DIR}/configure.cmake")
+file(WRITE "${_configure_cmake}"
+"execute_process(COMMAND sh ${_configure_script} WORKING_DIRECTORY ${SGX_SSL_PATCH_DIR} RESULT_VARIABLE result)
+if(result AND NOT result EQUAL 0)
+        message(FATAL_ERROR \"FAILED: \${result}\")
+endif()
+"
+)
+
+# Make
+set(_make_script "${SGX_SSL_PATCH_DIR}/intel_sgxssl_make.sh")
+if(SGX)
+    file(WRITE "${_make_script}"
+"#!/bin/sh
+if [ ! -d ${INTEL_SGXSSL_LIB_PATH} -o ! -e ${INTEL_SGXSSL_LIB_PATH}/libsgx_usgxssl.a ]; then
+        cd ${INTEL_SGXSSL_SRC}/Linux;
+        make -j$(nproc)
+fi;
+")
+endif()
+
+set(_make_cmake "${SGX_SSL_PATCH_DIR}/make.cmake")
+file(WRITE "${_make_cmake}"
+"execute_process(COMMAND sh ${_make_script} WORKING_DIRECTORY ${SGX_SSL_PATCH_DIR} RESULT_VARIABLE result)
+if(result AND NOT result EQUAL 0)
+    message(FATAL_ERROR \"FAILED: \${result}\")
+endif()
+"
+)
+
+# Install
+set(_install_script "${SGX_SSL_PATCH_DIR}/sgxssl_install.sh")
+if(SGX)
+    file(WRITE "${_install_script}"
+"#!/bin/sh
+cd ${INTEL_SGXSSL_SRC}/Linux
+install -d -m 0755 ${INTEL_SGXSSL_LIB_PATH}
+install -m 0755 ${INTEL_SGXSSL_LIB}/libsgx_usgxssl.a ${INTEL_SGXSSL_LIB_PATH}/libsgx_usgxssl.a
+install -m 0755 ${INTEL_SGXSSL_LIB}/libsgx_tsgxssl.a ${INTEL_SGXSSL_LIB_PATH}/libsgx_tsgxssl.a
+install -m 0755 ${INTEL_SGXSSL_LIB}/libsgx_tsgxssl_crypto.a ${INTEL_SGXSSL_LIB_PATH}/libsgx_tsgxssl_crypto.a
+install -m 0755 ${INTEL_SGXSSL_LIB}/libsgx_tsgxssl_ssl.a ${INTEL_SGXSSL_LIB_PATH}/libsgx_tsgxssl_ssl.a
+#sudo make install DESTDIR=/opt/librats/sgxssl/
+cd -
+")
+endif()
+
+set(_install_cmake "${SGX_SSL_PATCH_DIR}/install.cmake")
+file(WRITE "${_install_cmake}"
+"execute_process(COMMAND sh ${_install_script} WORKING_DIRECTORY ${SGX_SSL_PATCH_DIR} RESULT_VARIABLE result)
+if(result AND NOT result EQUAL 0)
+    message(FATAL_ERROR \"FAILED: \${result}\")
+endif()
+"
+)
+
+SET_DIRECTORY_PROPERTIES(PROPERTIES CLEAN_NO_CUSTOM 1)
+
+# Set intel-sgx-ssl git and compile parameters
+set(SGXSSL_URL           https://github.com/intel/intel-sgx-ssl.git)
+
+ExternalProject_Add(${PROJECT_NAME}
+        GIT_REPOSITORY          ${SGXSSL_URL}
+        GIT_TAG                 1e51eacc0de8cdd541fad05487e1db93c0c56540
+        PREFIX                  ${INTEL_SGXSSL_ROOT}
+        PATCH_COMMAND           ${CMAKE_COMMAND} -P ${_patch_cmake}
+        CONFIGURE_COMMAND       ${CMAKE_COMMAND} -P ${_configure_cmake}
+        BUILD_COMMAND           ${CMAKE_COMMAND} -P ${_make_cmake}
+        INSTALL_COMMAND         ${CMAKE_COMMAND} -P ${_install_cmake}
+)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(SGX)
+add_subdirectory(sgx-ssl)
+endif()

--- a/external/sgx-ssl/.gitignore
+++ b/external/sgx-ssl/.gitignore
@@ -1,0 +1,3 @@
+intel-sgx-ssl
+*.cmake
+*.sh

--- a/external/sgx-ssl/CMakeLists.txt
+++ b/external/sgx-ssl/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SGXSSL_SRC_PATH ${CMAKE_BINARY_DIR}/external/sgx-ssl/intel-sgx-ssl/src)
+set(SGXSSL_LIB_PATH ${SGXSSL_SRC_PATH}/intel-sgx-ssl/Linux/package/lib64)
+set(SGXSSL_INC_PATH ${SGXSSL_SRC_PATH}/intel-sgx-ssl/Linux/package/include)
+set(SGXSSL_LIB_FILES ${SGXSSL_LIB_PATH}/libsgx_usgxssl.a
+		     ${SGXSSL_LIB_PATH}/libsgx_tsgxssl.a
+                     ${SGXSSL_LIB_PATH}/libsgx_tsgxssl_ssl.a
+		     ${SGXSSL_LIB_PATH}/libsgx_tsgxssl_crypto.a
+                     )

--- a/external/sgx-ssl/patch/0001-add-ssl-library-enclave-support.patch
+++ b/external/sgx-ssl/patch/0001-add-ssl-library-enclave-support.patch
@@ -1,0 +1,807 @@
+From e15c26464a50895846977c9c8246e53247a476f0 Mon Sep 17 00:00:00 2001
+From: Liang Yang <liang3.yang@intel.com>
+Date: Fri, 3 Sep 2021 11:57:31 +0800
+Subject: [PATCH] add ssl library enclave support
+
+Signed-off-by: Liang Yang <liang3.yang@intel.com>
+---
+ Linux/Makefile                        |   1 +
+ Linux/build_openssl.sh                |   9 +-
+ Linux/package/include/sgx_tsgxssl.edl |  16 +-
+ Linux/package/include/tsgxsslio.h     |   9 +-
+ Linux/sgx/Makefile                    |   2 +
+ Linux/sgx/buildenv.mk                 |   2 +
+ Linux/sgx/libsgx_tsgxssl/tcommon.h    |   1 +
+ Linux/sgx/libsgx_tsgxssl/tstdio.cpp   | 218 +++++++++++++++++++++++++-
+ Linux/sgx/libsgx_tsgxssl/tstdlib.cpp  |  49 +++---
+ Linux/sgx/libsgx_tsgxssl/tunistd.cpp  | 117 ++++++--------
+ Linux/sgx/libsgx_usgxssl/ustdio.cpp   |  69 ++++++++
+ Linux/sgx/libsgx_usgxssl/ustdlib.cpp  |  32 ++++
+ Linux/sgx/libsgx_usgxssl/uunistd.cpp  |  14 ++
+ openssl_source/bypass_to_sgxssl.h     |  11 +-
+ 14 files changed, 439 insertions(+), 111 deletions(-)
+ create mode 100644 Linux/sgx/libsgx_usgxssl/ustdio.cpp
+ create mode 100644 Linux/sgx/libsgx_usgxssl/ustdlib.cpp
+ create mode 100644 Linux/sgx/libsgx_usgxssl/uunistd.cpp
+
+diff --git a/Linux/Makefile b/Linux/Makefile
+index 9524f45..304ce24 100644
+--- a/Linux/Makefile
++++ b/Linux/Makefile
+@@ -55,6 +55,7 @@ sgxssl_no_mitigation:
+ clean:
+ 	$(MAKE) -C sgx/ clean
+ 	rm -rf $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_INC)/openssl/
++	rm -rf $(PACKAGE_LIB)/$(OPENSSL_SSL_LIB)
+ 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_load
+ 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_cf
+ 
+diff --git a/Linux/build_openssl.sh b/Linux/build_openssl.sh
+index fdfffd5..e295c5f 100755
+--- a/Linux/build_openssl.sh
++++ b/Linux/build_openssl.sh
+@@ -69,8 +69,10 @@ sed -i '/OPENSSL_die("assertion failed/d' $OPENSSL_VERSION/include/openssl/crypt
+ fi
+ 
+ OUTPUT_LIB=libsgx_tsgxssl_crypto.a
++OUTPUT_SSLLIB=libsgx_tsgxssl_ssl.a
+ if [[ "$*" == *"debug"* ]] ; then
+-	OUTPUT_LIB=libsgx_tsgxssl_cryptod.a
++        OUTPUT_LIB=libsgx_tsgxssl_cryptod.a
++        OUTPUT_SSLLIB=libsgx_tsgxssl_ssld.a
+     ADDITIONAL_CONF="-g "
+ fi
+ 
+@@ -136,7 +138,7 @@ cp sgx_config.conf $OPENSSL_VERSION/ || exit 1
+ cp x86_64-xlate.pl $OPENSSL_VERSION/crypto/perlasm/ || exit 1
+ 
+ cd $SGXSSL_ROOT/../openssl_source/$OPENSSL_VERSION || exit 1
+-perl Configure --config=sgx_config.conf sgx-linux-x86_64 --with-rand-seed=none $ADDITIONAL_CONF $SPACE_OPT $MITIGATION_FLAGS no-idea no-mdc2 no-rc5 no-rc4 no-bf no-ec2m no-camellia no-cast no-srp no-hw no-dso no-shared no-ssl3 no-md2 no-md4 no-ui-console no-stdio no-afalgeng -D_FORTIFY_SOURCE=2 -DGETPID_IS_MEANINGLESS -include$SGXSSL_ROOT/../openssl_source/bypass_to_sgxssl.h --prefix=$OPENSSL_INSTALL_DIR || exit 1
++perl Configure --config=sgx_config.conf sgx-linux-x86_64 --with-rand-seed=none $ADDITIONAL_CONF $SPACE_OPT $MITIGATION_FLAGS no-idea no-mdc2 no-rc5 no-rc4 no-bf no-ec2m no-camellia no-cast no-srp no-hw no-dso no-shared no-ssl3 no-md2 no-md4 no-ui no-stdio no-afalgeng -D_FORTIFY_SOURCE=2 -DGETPID_IS_MEANINGLESS -include$SGXSSL_ROOT/../openssl_source/bypass_to_sgxssl.h -include$SGXSSL_ROOT/../Linux/package/include/tsgxsslio.h --prefix=$OPENSSL_INSTALL_DIR || exit 1
+ 
+ make build_all_generated || exit 1
+ 
+@@ -158,8 +160,9 @@ then
+     cp $SGXSSL_ROOT/../openssl_source/Linux/x86_64cpuid.s       ./crypto/x86_64cpuid.s
+ fi
+ 
+-make libcrypto.a || exit 1
++make libcrypto.a libssl.a || exit 1
+ cp libcrypto.a $SGXSSL_ROOT/package/lib64/$OUTPUT_LIB || exit 1
++cp libssl.a $SGXSSL_ROOT/package/lib64/$OUTPUT_SSLLIB || exit 1
+ objcopy --rename-section .init=Q6A8dc14f40efc4288a03b32cba4e $SGXSSL_ROOT/package/lib64/$OUTPUT_LIB || exit 1
+ cp include/openssl/* $SGXSSL_ROOT/package/include/openssl/ || exit 1
+ cp include/crypto/* $SGXSSL_ROOT/package/include/crypto/ || exit 1
+diff --git a/Linux/package/include/sgx_tsgxssl.edl b/Linux/package/include/sgx_tsgxssl.edl
+index cbc4888..ffcb5b2 100644
+--- a/Linux/package/include/sgx_tsgxssl.edl
++++ b/Linux/package/include/sgx_tsgxssl.edl
+@@ -36,7 +36,21 @@ enclave {
+     from "sgx_tstdc.edl" import *;
+     
+     untrusted {
+-    	 void u_sgxssl_ftime([out, size=timeb_len] void * timeptr, uint32_t timeb_len);
++            void u_sgxssl_ftime([out, size=timeb_len] void * timeptr, uint32_t timeb_len);
++            int ocall_sgxssl_read(int fd, [out, size = buf_len] void *buf, size_t buf_len);
++            int ocall_sgxssl_write(int fd, [in, size = buf_len] const void *buf, size_t buf_len);
++            int ocall_sgxssl_getenv([in, size = name_len] const char *name, size_t name_len, [out, size = buf_len] void *buf, int buf_len, [out] int *need_len);
++            uint64_t ocall_sgxssl_fopen([in, size = filename_len] const char *filename, size_t filename_len, [in, size = mode_len] const char *mode, size_t mode_len);
++            int ocall_sgxssl_fclose(uint64_t fp);
++            int ocall_sgxssl_ferror(uint64_t fp);
++            int ocall_sgxssl_feof(uint64_t fp);
++            int ocall_sgxssl_fflush(uint64_t fp);
++            long ocall_sgxssl_ftell(uint64_t fp);
++            int ocall_sgxssl_fseek(uint64_t fp, long offset, int origin);
++            size_t ocall_sgxssl_fread([out, size = total_size] void *buf, size_t total_size, size_t element_size, size_t cnt, uint64_t fp);
++            size_t ocall_sgxssl_fwrite([in, size = total_size] const void *buf, size_t total_size, size_t element_size, size_t cnt, uint64_t fp);
++            int ocall_sgxssl_fgets([out, size = max_cnt] char *str, int max_cnt, uint64_t fp);
++            int ocall_sgxssl_fputs([in, size = total_size] const char *str, size_t total_size, uint64_t fp);
+     };
+ 
+     trusted {
+diff --git a/Linux/package/include/tsgxsslio.h b/Linux/package/include/tsgxsslio.h
+index a200a17..6a38de1 100644
+--- a/Linux/package/include/tsgxsslio.h
++++ b/Linux/package/include/tsgxsslio.h
+@@ -32,6 +32,13 @@
+ #ifndef _TSGXSSL_IO_H_
+ #define _TSGXSSL_IO_H_
+ 
+-typedef void FILE;
++#include <stdio.h>
++
++#undef stdout
++#define stdout  ((void*)1)
++#undef  stderr
++#define stderr  ((void*)2)
++
++typedef struct _IO_FILE FILE;
+ 
+ #endif // _TSGXSSL_IO_H_
+diff --git a/Linux/sgx/Makefile b/Linux/sgx/Makefile
+index 2cfed73..74ac77f 100644
+--- a/Linux/sgx/Makefile
++++ b/Linux/sgx/Makefile
+@@ -61,9 +61,11 @@ endif
+ 
+ ifneq ($(MITIGATION-CVE-2020-0551),)
+ 	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(TRUSTED_LIB)
++	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(OPENSSL_SSL_LIB)
+ 	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(OPENSSL_LIB)
+ 	mkdir -p $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)
+ 	mv $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
++	mv $(PACKAGE_LIB)/$(OPENSSL_SSL_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
+ 	mv $(PACKAGE_LIB)/$(TRUSTED_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
+ endif
+ 
+diff --git a/Linux/sgx/buildenv.mk b/Linux/sgx/buildenv.mk
+index cd8818e..7cd794c 100644
+--- a/Linux/sgx/buildenv.mk
++++ b/Linux/sgx/buildenv.mk
+@@ -73,11 +73,13 @@ endif
+ ifeq ($(DEBUG), 1)
+ 	OBJDIR := debug
+ 	OPENSSL_LIB := libsgx_tsgxssl_cryptod.a
++	OPENSSL_SSL_LIB := libsgx_tsgxssl_ssld.a
+ 	TRUSTED_LIB := libsgx_tsgxssld.a
+ 	UNTRUSTED_LIB := libsgx_usgxssld.a
+ else
+ 	OBJDIR := release
+ 	OPENSSL_LIB := libsgx_tsgxssl_crypto.a
++	OPENSSL_SSL_LIB := libsgx_tsgxssl_ssl.a
+ 	TRUSTED_LIB := libsgx_tsgxssl.a
+ 	UNTRUSTED_LIB := libsgx_usgxssl.a
+ endif
+diff --git a/Linux/sgx/libsgx_tsgxssl/tcommon.h b/Linux/sgx/libsgx_tsgxssl/tcommon.h
+index f8d9379..5b6136c 100644
+--- a/Linux/sgx/libsgx_tsgxssl/tcommon.h
++++ b/Linux/sgx/libsgx_tsgxssl/tcommon.h
+@@ -40,6 +40,7 @@
+ #include "tdefines.h"
+ #include "tSgxSSL_api.h"
+ 
++#define SGX_SSL_SUCCESS 0
+ 
+ //#define DO_SGX_LOG
+ #define DO_SGX_WARN
+diff --git a/Linux/sgx/libsgx_tsgxssl/tstdio.cpp b/Linux/sgx/libsgx_tsgxssl/tstdio.cpp
+index 800a9a7..17f9bf6 100644
+--- a/Linux/sgx/libsgx_tsgxssl/tstdio.cpp
++++ b/Linux/sgx/libsgx_tsgxssl/tstdio.cpp
+@@ -30,9 +30,11 @@
+  */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include "tcommon.h"
+ #include "sgx_tsgxssl_t.h"
+ #include "tSgxSSL_api.h"
++#include "tsgxsslio.h"
+ 
+ extern PRINT_TO_STDOUT_STDERR_CB s_print_cb;
+ 
+@@ -48,8 +50,222 @@ int sgx_print(const char *format, ...)
+ 
+ 		return res;
+ 	}
+-	
++
+ 	return 0;
+ }
+ 
++int print_with_cb(void *fp, const char *fmt, __va_list vl)
++{
++	int res = -1;
++	int stream = -1;
++
++	if (fp == NULL || s_print_cb == NULL)
++		return -1;
++
++	if (fp == stdout)
++		stream = STREAM_STDOUT;
++	else if (fp == stderr)
++		stream = STREAM_STDERR;
++	else
++		return res;
++
++	res = s_print_cb((Stream_t)stream, fmt, vl);
++
++	return res;
++}
++
++void *sgxssl_fopen(const char *filename, const char *mode)
++{
++	uint64_t ret = 0;
++	int res;
++
++	if (filename == NULL || mode == NULL)
++		return NULL;
++
++	res = ocall_sgxssl_fopen(&ret, filename, strlen(filename) + 1, mode, strlen(mode) + 1);
++	if (res != SGX_SSL_SUCCESS)
++		return NULL;
++
++	return (void *)ret;
++}
++
++int sgxssl_fclose(void *fp)
++{
++	int ret = -1;
++	int res;
++
++	if (fp == NULL)
++		return -1;
++
++	res = ocall_sgxssl_fclose(&ret, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return -1;
++
++	return ret;
++}
++
++int sgxssl_ferror(void *fp)
++{
++	int ret = -1;
++	int res;
++
++	if (fp == NULL)
++		return -1;
++
++	res = ocall_sgxssl_ferror(&ret, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return -1;
++
++	return ret;
++}
++
++int sgxssl_feof(void *fp)
++{
++	int ret = 0;
++	int res;
++
++	if (fp == NULL)
++		return 0;
++
++	res = ocall_sgxssl_feof(&ret, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return 0;
++
++	return ret;
++}
++
++int sgxssl_fflush(void *fp)
++{
++	int ret = -1;
++	int res;
++
++	if (fp == NULL)
++		return -1;
++
++	res = ocall_sgxssl_fflush(&ret, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return -1;
++
++	return ret;
++}
++
++long sgxssl_ftell(void *fp)
++{
++	long ret = -1;
++	int res;
++
++	if (fp == NULL)
++		return -1;
++
++	res = ocall_sgxssl_ftell(&ret, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return -1;
++
++	return ret;
++}
++
++int sgxssl_fseek(void *fp, long offset, int origin)
++{
++	int ret = -1;
++	int res;
++
++	if (fp == NULL)
++		return -1;
++
++	res = ocall_sgxssl_fseek(&ret, (uint64_t)fp, offset, origin);
++	if (res != SGX_SSL_SUCCESS)
++		return -1;
++
++	return ret;
++}
++
++int sgxssl_fprintf(void *fp, const char *format, ...)
++{
++	if (s_print_cb != NULL) {
++		va_list vl;
++		va_start(vl, format);
++		int res = print_with_cb(fp, format, vl);
++		va_end(vl);
++
++		return res;
++	}
++
++	return -1;
++}
++
++int sgxssl_vfprintf(void *fp, const char *format, va_list vl)
++{
++	if (s_print_cb != NULL) {
++		int res = print_with_cb(fp, format, vl);
++		return res;
++	}
++
++	return -1;
++}
++
++size_t sgxssl_fread(void *dest, size_t element_size, size_t cnt, void *fp)
++{
++	size_t ret = 0;
++	int res;
++
++	if (fp == NULL || dest == NULL || element_size == 0 || cnt == 0)
++		return 0;
++
++	if (element_size > (SIZE_MAX - 1) / cnt + 1)
++		return 0;
++
++	res = ocall_sgxssl_fread(&ret, dest, element_size * cnt, element_size, cnt, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return 0;
++
++	return ret;
++}
++
++size_t sgxssl_fwrite(const void *src, size_t element_size, size_t cnt, void *fp)
++{
++	size_t ret = 0;
++	int res;
++
++	if (fp == NULL || src == NULL || element_size == 0 || cnt == 0)
++		return 0;
++
++	if (element_size > (SIZE_MAX - 1) / cnt + 1)
++		return 0;
++
++	res = ocall_sgxssl_fwrite(&ret, src, element_size * cnt, element_size, cnt, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS)
++		return 0;
++
++	return ret;
++}
++
++char *sgxssl_fgets(char *dest, int max_cnt, void *fp)
++{
++	int ret = -1;
++	int res;
++
++	if (fp == NULL || dest == NULL || max_cnt <= 0)
++		return NULL;
++
++	res = ocall_sgxssl_fgets(&ret, dest, max_cnt, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS || ret < 0)
++		return NULL;
++
++	return dest;
++}
++
++int sgxssl_fputs(const char *src, void *fp)
++{
++	int ret = -1;
++	int res;
++
++	if (fp == NULL || src == NULL)
++		return -1;
++
++	res = ocall_sgxssl_fputs(&ret, src, strlen(src) + 1, (uint64_t)fp);
++	if (res != SGX_SSL_SUCCESS || ret < 0)
++		return -1;
++
++	return ret;
++}
+ }
+diff --git a/Linux/sgx/libsgx_tsgxssl/tstdlib.cpp b/Linux/sgx/libsgx_tsgxssl/tstdlib.cpp
+index 81851a7..243e630 100644
+--- a/Linux/sgx/libsgx_tsgxssl/tstdlib.cpp
++++ b/Linux/sgx/libsgx_tsgxssl/tstdlib.cpp
+@@ -57,39 +57,26 @@ SGX_ACCESS_VERSION(tssl, 1);
+ 
+ extern "C" {
+ 
++#define MAX_ENV_BUF_LEN 4096
++static __thread char env_buf[MAX_ENV_BUF_LEN];
++
+ char *sgxssl_getenv(const char *name)
+ {
+-	FSTART;
+-
+-	if (name == NULL ) {
+-		FEND;
+-		return NULL;
+-	}
+-
+-	if (!strcmp(name, "OPENSSL_CONF" )) {
+-		FEND;
+-		return NULL;
+-	}
+-
+-	if (!strcmp(name, "OPENSSL_ENGINES" )) {
+-		FEND;
+-		return (char *) PATH_DEV_NULL;
+-	}
+-
+-	if (!strcmp(name, "OPENSSL_ALLOW_PROXY_CERTS" )) {
+-		FEND;
+-		return NULL;
+-	}
+-	
+-	if (!strcmp(name, "OPENSSL_ia32cap" )) {
+-		FEND;
+-		return NULL;
+-	}
+-
+-	SGX_UNREACHABLE_CODE(SET_ERRNO);
+-
+-	FEND;
+-	return NULL;
++        int ret = 0;
++        int res;
++        int buf_len = 0;
++
++        if (env_buf == NULL || MAX_ENV_BUF_LEN <= 0) {
++                return NULL;
++        }
++
++        memset(env_buf, 0, MAX_ENV_BUF_LEN);
++        res = ocall_sgxssl_getenv(&ret, name, strlen(name), env_buf, MAX_ENV_BUF_LEN, &buf_len);
++        if (res != SGX_SSL_SUCCESS || ret <= 0 || ret != buf_len) {
++                return NULL;
++        }
++
++        return env_buf;
+ }
+ 
+ }
+diff --git a/Linux/sgx/libsgx_tsgxssl/tunistd.cpp b/Linux/sgx/libsgx_tsgxssl/tunistd.cpp
+index 7bdfa07..3a21c5a 100644
+--- a/Linux/sgx/libsgx_tsgxssl/tunistd.cpp
++++ b/Linux/sgx/libsgx_tsgxssl/tunistd.cpp
+@@ -32,110 +32,94 @@
+ #include "sgx_tsgxssl_t.h"
+ #include "tcommon.h"
+ 
+-#define FAKE_PIPE_READ_FD	0xFAFAFAFALL
+-#define FAKE_PIPE_WRITE_FD	0xFBFBFBFBLL
++#define FAKE_PIPE_READ_FD      0xFAFAFAFALL
++#define FAKE_PIPE_WRITE_FD     0xFBFBFBFBLL
+ 
+-#define ENCLAVE_PAGE_SIZE	0x1000	// 4096 B
++#define ENCLAVE_PAGE_SIZE      0x1000  // 4096 B
+ 
+ extern "C" {
+ 
+ int sgxssl_pipe (int pipefd[2])
+ {
+-	FSTART;
++       FSTART;
+ 
+-	// The function is used only by the engines/e_dasync.c (dummy async engine).
+-	// Adding fake implementation only to be able to distinguish pipe read/write from socket read/write
+-	pipefd[0] = FAKE_PIPE_READ_FD;
+-	pipefd[1] = FAKE_PIPE_WRITE_FD;
++       // The function is used only by the engines/e_dasync.c (dummy async engine).
++       // Adding fake implementation only to be able to distinguish pipe read/write from socket read/write
++       pipefd[0] = FAKE_PIPE_READ_FD;
++       pipefd[1] = FAKE_PIPE_WRITE_FD;
+ 
+-	FEND;
++       FEND;
+ 
+-	// On error, -1 is returned, and errno is set appropriately
+-	return 0;
++       // On error, -1 is returned, and errno is set appropriately
++       return 0;
+ }
+ 
+ size_t sgxssl_write (int fd, const void *buf, size_t n)
+ {
+-	FSTART;
++    int ret = 0;
++    int res;
+ 
+-	if (fd == FAKE_PIPE_WRITE_FD) {
+-		// With pipes the function is used only by the engines/e_dasync.c (dummy async engine).
+-		SGX_UNSUPPORTED_FUNCTION(SET_ERRNO);
++    if (fd == FAKE_PIPE_WRITE_FD)
++        return -1;
+ 
+-		FEND;
+-		// On error, -1 is returned, and errno is set appropriately
+-		return -1;
+-	}
+-
+-	// In addition, the function is used by bss_sock.c as writesocket function.
+-	// It is unreachable under the assumption that TLS support is not required.
+-	// Otherwise should be implemented as OCALL.
+-	SGX_UNREACHABLE_CODE(SET_ERRNO);
+-	FEND;
+-
+-	return -1;
++    res = ocall_sgxssl_write(&ret, fd, buf, n);
++    if (res != SGX_SSL_SUCCESS)
++        return -1;
+ 
++    return ret;
+ }
+ 
+ size_t sgxssl_read(int fd, void *buf, size_t count)
+ {
+-	FSTART;
++    int ret = 0;
++    int res;
+ 
+-	if (fd == FAKE_PIPE_READ_FD) {
+-		// With pipes the function is used only by the engines/e_dasync.c (dummy async engine).
+-		SGX_UNSUPPORTED_FUNCTION(SET_ERRNO);
++    if (fd == FAKE_PIPE_READ_FD)
++        return -1;
+ 
+-		FEND;
+-		// On error, -1 is returned, and errno is set appropriately
+-		return -1;
+-	}
++    res = ocall_sgxssl_read(&ret, fd, buf, count);
++    if (res != SGX_SSL_SUCCESS)
++        return -1;
+ 
+-	// In addition, the function is used by bss_sock.c as readsocket function.
+-	// It is unreachable under the assumption that TLS support is not required.
+-	// Otherwise should be implemented as OCALL.
+-	SGX_UNREACHABLE_CODE(SET_ERRNO);
+-	FEND;
+-
+-	return -1;
++    return ret;
+ }
+ 
+-// TODO
+ int sgxssl_close(int fd)
+ {
+-	FSTART;
++       FSTART;
+ 
+-	if (fd == FAKE_PIPE_READ_FD ||
+-		fd == FAKE_PIPE_WRITE_FD) {
+-		// With pipes the function is used only by the engines/e_dasync.c (dummy async engine).
+-		SGX_UNSUPPORTED_FUNCTION(SET_ERRNO);
++       if (fd == FAKE_PIPE_READ_FD ||
++               fd == FAKE_PIPE_WRITE_FD) {
++               // With pipes the function is used only by the engines/e_dasync.c (dummy async engine).
++               SGX_UNSUPPORTED_FUNCTION(SET_ERRNO);
+ 
+-		FEND;
+-		// On error, -1 is returned, and errno is set appropriately
+-		return -1;
+-	}
++               FEND;
++               // On error, -1 is returned, and errno is set appropriately
++               return -1;
++       }
+ 
+-	// In addition, the function is used by b_sock2.c as closesocket function.
+-	// It is unreachable under the assumption that TLS support is not required.
+-	// Otherwise should be implemented as OCALL.
+-	SGX_UNREACHABLE_CODE(SET_ERRNO);
+-	FEND;
++       // In addition, the function is used by b_sock2.c as closesocket function.
++       // It is unreachable under the assumption that TLS support is not required.
++       // Otherwise should be implemented as OCALL.
++       SGX_UNREACHABLE_CODE(SET_ERRNO);
++       FEND;
+ 
+-	return -1;
++       return -1;
+ }
+ 
+ long sgxssl_sysconf(int name)
+ {
+-	FSTART;
++       FSTART;
+ 
+-	// Used by mem_sec.c
+-	if (name == _SC_PAGESIZE) {
+-		return ENCLAVE_PAGE_SIZE;
+-	}
++       // Used by mem_sec.c
++       if (name == _SC_PAGESIZE) {
++               return ENCLAVE_PAGE_SIZE;
++       }
+ 
+-	SGX_UNREACHABLE_CODE(SET_ERRNO);
+-	FEND;
++       SGX_UNREACHABLE_CODE(SET_ERRNO);
++       FEND;
+ 
+-	return -1;
++       return -1;
+ }
+ 
+ //Process ID is used as RNG entropy, SGXSSL use sgx_get_rand() hence this function is redundant.
+@@ -198,5 +182,4 @@ void *sgxssl_opendir(const char *name)
+     return NULL;
+ }
+ 
+-
+ } // extern "C"
+diff --git a/Linux/sgx/libsgx_usgxssl/ustdio.cpp b/Linux/sgx/libsgx_usgxssl/ustdio.cpp
+new file mode 100644
+index 0000000..fa085e7
+--- /dev/null
++++ b/Linux/sgx/libsgx_usgxssl/ustdio.cpp
+@@ -0,0 +1,69 @@
++#include <stdio.h>
++#include <stdint.h>
++#include <string.h>
++
++extern "C" {
++
++uint64_t ocall_sgxssl_fopen(const char *filename, size_t filename_len, const char *mode,
++			    size_t mode_len)
++{
++	FILE *file_host = fopen(filename, mode);
++	return (uint64_t)file_host;
++}
++
++int ocall_sgxssl_fclose(uint64_t fp)
++{
++	return fclose((FILE *)fp);
++}
++
++int ocall_sgxssl_ferror(uint64_t fp)
++{
++	return ferror((FILE *)fp);
++}
++
++int ocall_sgxssl_feof(uint64_t fp)
++{
++	return feof((FILE *)fp);
++}
++
++int ocall_sgxssl_fflush(uint64_t fp)
++{
++	return fflush((FILE *)fp);
++}
++
++int ocall_sgxssl_ftell(uint64_t fp)
++{
++	return ftell((FILE *)fp);
++}
++
++int ocall_sgxssl_fseek(uint64_t fp, long offset, int origin)
++{
++	return fseek((FILE *)fp, offset, origin);
++}
++
++size_t ocall_sgxssl_fread(void *buf, size_t total_size, size_t element_size, size_t cnt,
++			  uint64_t fp)
++{
++	return fread(buf, element_size, cnt, (FILE *)fp);
++}
++
++size_t ocall_sgxssl_fwrite(const void *buf, size_t total_size, size_t element_size, size_t cnt,
++			   uint64_t fp)
++{
++	return fwrite(buf, element_size, cnt, (FILE *)fp);
++}
++
++int ocall_sgxssl_fgets(char *str, int max_cnt, uint64_t fp)
++{
++	if (fgets(str, max_cnt, (FILE *)fp) != NULL) {
++		return 0;
++	} else {
++		return -1;
++	}
++}
++
++int ocall_sgxssl_fputs(const char *str, size_t total_size, uint64_t fp)
++{
++	return fputs(str, (FILE *)fp);
++}
++}
+diff --git a/Linux/sgx/libsgx_usgxssl/ustdlib.cpp b/Linux/sgx/libsgx_usgxssl/ustdlib.cpp
+new file mode 100644
+index 0000000..6a07ba9
+--- /dev/null
++++ b/Linux/sgx/libsgx_usgxssl/ustdlib.cpp
+@@ -0,0 +1,32 @@
++#include <stdlib.h>
++#include <string.h>
++
++extern "C" {
++
++int ocall_sgxssl_getenv(const char *name, int name_len, void *buf, int buf_len, int *need_len)
++{
++	char *get_buf = NULL;
++
++	if (name == NULL || need_len == NULL || buf_len <= 0) {
++		return -1;
++	}
++
++	get_buf = getenv(name);
++	if (get_buf == NULL) {
++		*need_len = 0;
++		return 0;
++	}
++
++	*need_len = strlen(get_buf) + 1;
++	if (*need_len > buf_len) {
++		return 0;
++	}
++
++	if (buf == NULL) {
++		return -1;
++	}
++	memcpy(buf, get_buf, *need_len);
++
++	return (*need_len);
++}
++}
+diff --git a/Linux/sgx/libsgx_usgxssl/uunistd.cpp b/Linux/sgx/libsgx_usgxssl/uunistd.cpp
+new file mode 100644
+index 0000000..5bc55aa
+--- /dev/null
++++ b/Linux/sgx/libsgx_usgxssl/uunistd.cpp
+@@ -0,0 +1,14 @@
++#include <unistd.h>
++
++extern "C" {
++
++int ocall_sgxssl_read(int fd, void *buf, size_t buf_len)
++{
++	return read(fd, buf, buf_len);
++}
++
++int ocall_sgxssl_write(int fd, const void *buf, size_t buf_len)
++{
++	return write(fd, buf, buf_len);
++}
++}
+diff --git a/openssl_source/bypass_to_sgxssl.h b/openssl_source/bypass_to_sgxssl.h
+index 6ff3fc2..8c2638e 100644
+--- a/openssl_source/bypass_to_sgxssl.h
++++ b/openssl_source/bypass_to_sgxssl.h
+@@ -181,23 +181,20 @@
+ #define mlock sgxssl_mlock
+ #define madvise sgxssl_madvise
+ 
+-/*
+-#define fopen64 sgxssl_fopen64
+ #define fopen sgxssl_fopen
+-#define wfopen sgxssl_wfopen
+ #define fclose sgxssl_fclose
+ #define ferror sgxssl_ferror
+ #define feof sgxssl_feof
+ #define fflush sgxssl_fflush
+ #define ftell sgxssl_ftell
+ #define fseek sgxssl_fseek
+-#define fread sgxssl_fread
+ #define fwrite sgxssl_fwrite
+-#define fgets sgxssl_fgets
+ #define fputs sgxssl_fputs
+-#define fileno sgxssl_fileno
+ #define __fprintf_chk sgxssl_fprintf
+-*/
++
++#define __vfprintf_chk sgxssl_vfprintf
++#define __fread_alias sgxssl_fread
++#define __fgets_alias sgxssl_fgets
+ 
+ #if defined(SGXSDK_INT_VERSION) && (SGXSDK_INT_VERSION > 18)
+ 	#define _longjmp longjmp
+-- 
+2.27.0
+


### PR DESCRIPTION
This PR add SGXSSL as a dependency of librats, which makes it possible to use openssl in sgx environment.

Most of these files are copy from rats-tls project.

depends on #71 

Signed-off-by: Kun Lai <me@imlk.top>