### PR TITLE
librats: add user-defined attester, verifier, crypto and log-level

### DIFF
--- a/api/librats_verify_attestation_certificate.c
+++ b/api/librats_verify_attestation_certificate.c
@@ -14,23 +14,28 @@
  * @param verify_claims_callback[IN] - A user-provided callback function pointer, which will be called during validation.
  * @param args[IN] - A pointer that will be used as one of arguments when verify_claims_callback is called.
  */
-rats_verifier_err_t
-librats_verify_attestation_certificate(uint8_t *certificate, size_t certificate_size,
-				       rats_verify_claims_callback_t verify_claims_callback,
-				       void *args)
+rats_verifier_err_t librats_verify_attestation_certificate(
+	rats_conf_t conf, uint8_t *certificate, size_t certificate_size,
+	rats_verify_claims_callback_t verify_claims_callback, void *args)
 {
 	rats_verifier_err_t ret = RATS_VERIFIER_ERR_UNKNOWN;
 	crypto_wrapper_err_t crypto_ret = CRYPTO_WRAPPER_ERR_UNKNOWN;
 
 	rats_core_context_t ctx;
-	rats_conf_t conf;
 	bool verifier_initialized = false;
 	bool crypto_wrapper_initialized = false;
 
 	memset(&ctx, 0, sizeof(rats_core_context_t));
-	memset(&conf, 0, sizeof(rats_conf_t));
 
 	conf.api_version = RATS_API_VERSION_DEFAULT;
+	if (conf.log_level < 0 || conf.log_level > RATS_LOG_LEVEL_MAX) {
+		rats_global_log_level = rats_global_core_context.config.log_level;
+		RATS_WARN("log level is illegal, reset to global value %d\n",
+			  rats_global_core_context.config.log_level);
+	} else {
+		rats_global_log_level = conf.log_level;
+	}
+
 	if ((ret = rats_verifier_init(&conf, &ctx)) != RATS_VERIFIER_ERR_NONE)
 		goto err;
 	verifier_initialized = true;

--- a/core/rats_common.c
+++ b/core/rats_common.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <librats/conf.h>
 #include <librats/api.h>
 #include <librats/log.h>
 #include <internal/core.h>
@@ -39,6 +40,7 @@ rats_core_context_t rats_global_core_context = {
         .attester_type = "\0",
         .verifier_type = "\0",
 		.crypto_type = "\0",
+		.log_level = RATS_LOG_LEVEL_DEFAULT,
     },
     .flags = 0L,
     .attester = NULL,

--- a/include/librats/api.h
+++ b/include/librats/api.h
@@ -62,13 +62,13 @@ int librats_verify_evidence_from_json(const char *json_string, const uint8_t *ha
 extern "C" {
 #endif
 
-extern rats_attester_err_t librats_get_attestation_certificate(
+extern rats_attester_err_t librats_get_attestation_certificate(rats_conf_t conf, 
 	rats_cert_subject_t subject_name, uint8_t **privkey /* PEM format */, size_t *privkey_len,
 	const claim_t *custom_claims, size_t custom_claims_length, bool provide_endorsements,
 	uint8_t **certificate_out, size_t *certificate_size_out);
 
 extern rats_verifier_err_t
-librats_verify_attestation_certificate(uint8_t *certificate, size_t certificate_size,
+librats_verify_attestation_certificate(rats_conf_t conf, uint8_t *certificate, size_t certificate_size,
 				       rats_verify_claims_callback_t verify_claims_callback,
 				       void *args);
 

--- a/include/librats/conf.h
+++ b/include/librats/conf.h
@@ -8,6 +8,7 @@
 #define _LIBRATS_CONF_H
 
 #include <librats/hash.h>
+#include <stdbool.h>
 
 typedef enum {
 	RATS_LOG_LEVEL_DEBUG,
@@ -33,6 +34,7 @@ typedef struct rats_conf {
 	char attester_type[32];
 	char verifier_type[32];
 	char crypto_type[32];
+	rats_log_level_t log_level;
 	rats_key_algo_t key_algo;
 	rats_hash_algo_t hash_algo;
 } rats_conf_t;

--- a/samples/cert-app/README.md
+++ b/samples/cert-app/README.md
@@ -6,6 +6,48 @@ This program will first generate the certificate in the TEE, copy it outside the
 
 Note: Running in host mode is not supported due to the need to generate certificates.
 
+## Run cert-app
+
+```sh
+cd /usr/share/librats/samples
+./cert-app
+```
+
+### Specify the instance type
+
+The options of `cert-app` are as followed:
+
+```sh
+Options：
+
+        --debug-enclave/-d            set to enable enclave debugging
+        --no-privkey/-k               set to enable key pairs generation in librats
+        --add-claim/-C key:val        add a user-defined custom claims.
+        --attester/-a value   	      set the type of quote attester
+        --verifier/-v value   	      set the type of quote verifier
+        --crypto/-c value     	      set the type of crypto wrapper
+        --log-level/-l                set the log level
+        --help/-h                     show the usage
+```
+
+You can set command line parameters to specify different configurations.
+
+For example:
+
+```sh
+./cert-app -a nullattester -v nullverifier
+./cert-app -a sgx_ecdsa -v sgx_ecdsa_qve
+./cert-app -a sgx_la -v sgx_la
+./cert-app -c openssl
+./cert-app -C "claim_0:value_0"
+```
+
+Librats's log level can be set through `-l` option with 6 levels: `off`, `fatal`, `error`, `warn`, `info`, and `debug`. The default level is error. The most verbose level is debug.
+
+```
+./cert-app -l debug
+```
+
 ## debug
 
 The generated certificate will be dumped to `/tmp/cert.der`. Here are some code snippets to let you parse the certificate manually from the command line:

--- a/samples/cert-app/common.c
+++ b/samples/cert-app/common.c
@@ -130,7 +130,7 @@ int verify_callback(claim_t *claims, size_t claims_size, void *args_in)
 	return ret;
 }
 
-int get_attestation_certificate(bool no_privkey, const claim_t *custom_claims,
+int get_attestation_certificate(rats_conf_t conf, bool no_privkey, const claim_t *custom_claims,
 				size_t custom_claims_size, uint8_t **certificate_out,
 				size_t *certificate_size_out)
 {
@@ -154,7 +154,7 @@ int get_attestation_certificate(bool no_privkey, const claim_t *custom_claims,
 
 	printf("\nGenerate certificate with librats now ...\n");
 	/* Collect certificate */
-	rats_ret = librats_get_attestation_certificate(subject_name, &private_key,
+	rats_ret = librats_get_attestation_certificate(conf, subject_name, &private_key,
 						       &private_key_size, custom_claims,
 						       custom_claims_size, true, certificate_out,
 						       certificate_size_out);
@@ -181,7 +181,8 @@ err:
 	return ret;
 }
 
-int verify_attestation_certificate(uint8_t *certificate, size_t certificate_size, void *args)
+int verify_attestation_certificate(rats_conf_t conf, uint8_t *certificate, size_t certificate_size,
+				   void *args)
 {
 	int ret = -1;
 	rats_verifier_err_t rats_ret;
@@ -189,7 +190,7 @@ int verify_attestation_certificate(uint8_t *certificate, size_t certificate_size
 	printf("\nVerify certificate with librats now ...\n");
 
 	/* Verify certificate */
-	rats_ret = librats_verify_attestation_certificate(certificate, certificate_size,
+	rats_ret = librats_verify_attestation_certificate(conf, certificate, certificate_size,
 							  verify_callback, args);
 	if (rats_ret != RATS_VERIFIER_ERR_NONE) {
 		printf("Failed to verify certificate %#x\n", rats_ret);

--- a/samples/sgx-stub-enclave/sgx_stub.edl
+++ b/samples/sgx-stub-enclave/sgx_stub.edl
@@ -8,14 +8,14 @@ enclave {
         from "../../external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/include/sgx_tsgxssl.edl" import *;
 
         trusted {
-                public int ecall_get_attestation_certificate(bool no_privkey,
+                public int ecall_get_attestation_certificate(rats_conf_t conf, bool no_privkey,
                                 [user_check] const claim_t *custom_claims,
                                 size_t custom_claims_size,
                                 size_t certificate_capacity,
                                 [out, count=certificate_capacity] uint8_t *certificate_out,
                                 [out] size_t *certificate_size_out);
 
-                public int ecall_verify_attestation_certificate([in, count=certificate_size] uint8_t *certificate,
+                public int ecall_verify_attestation_certificate(rats_conf_t conf, [in, count=certificate_size] uint8_t *certificate,
                                 size_t certificate_size,
                                 [user_check] void *args);
         };

--- a/samples/sgx-stub-enclave/sgx_stub_ecall.c
+++ b/samples/sgx-stub-enclave/sgx_stub_ecall.c
@@ -15,14 +15,15 @@
 
 #include "../cert-app/common.c"
 
-int ecall_get_attestation_certificate(bool no_privkey, const claim_t *custom_claims,
-				      size_t custom_claims_size, size_t certificate_capacity,
-				      uint8_t *certificate_out, size_t *certificate_size_out)
+int ecall_get_attestation_certificate(rats_conf_t conf, bool no_privkey,
+				      const claim_t *custom_claims, size_t custom_claims_size,
+				      size_t certificate_capacity, uint8_t *certificate_out,
+				      size_t *certificate_size_out)
 {
 	uint8_t *certificate = NULL;
 	size_t certificate_size;
 
-	int ret = get_attestation_certificate(no_privkey, custom_claims, custom_claims_size,
+	int ret = get_attestation_certificate(conf, no_privkey, custom_claims, custom_claims_size,
 					      &certificate, &certificate_size);
 	if (ret == 0) {
 		if (certificate_size > certificate_capacity) {
@@ -40,7 +41,8 @@ int ecall_get_attestation_certificate(bool no_privkey, const claim_t *custom_cla
 	return ret;
 }
 
-int ecall_verify_attestation_certificate(uint8_t *certificate, size_t certificate_size, void *args)
+int ecall_verify_attestation_certificate(rats_conf_t conf, uint8_t *certificate,
+					 size_t certificate_size, void *args)
 {
-	return verify_attestation_certificate(certificate, certificate_size, args);
+	return verify_attestation_certificate(conf, certificate, certificate_size, args);
 }


### PR DESCRIPTION
Added the function of user-defined attester, verifier, crypto and log-level, the specific usage can be found in ./cert-app -h