### PR TITLE
verifiers: use type instead of name for selection

### DIFF
--- a/crypto_wrappers/api/crypto_wrapper_verify_certificate_extension.c
+++ b/crypto_wrappers/api/crypto_wrapper_verify_certificate_extension.c
@@ -39,7 +39,7 @@ crypto_wrapper_verify_evidence(crypto_wrapper_ctx_t *crypto_ctx, attestation_evi
 		RATS_WARN("type doesn't match between verifier '%s' and evidence '%s'\n",
 			  crypto_ctx->rats_handle->verifier->opts->name, evidence->type);
 		rats_verifier_err_t verifier_ret =
-			rats_verifier_select(crypto_ctx->rats_handle, evidence->type);
+			rats_verifier_select_by_type(crypto_ctx->rats_handle, evidence->type);
 		if (verifier_ret != RATS_VERIFIER_ERR_NONE) {
 			RATS_ERR("the verifier selecting err %#x during verifying cert extension\n",
 				 verifier_ret);

--- a/include/internal/verifier.h
+++ b/include/internal/verifier.h
@@ -15,6 +15,7 @@ extern rats_verifier_err_t rats_verifier_init_static(const char *name);
 extern rats_verifier_err_t rats_verifier_load_all(void);
 extern rats_verifier_err_t rats_verifier_post_init(const char *name, void *handle);
 extern rats_verifier_err_t rats_verifier_select(rats_core_context_t *, const char *);
+extern rats_verifier_err_t rats_verifier_select_by_type(rats_core_context_t *, const char *);
 extern rats_verifier_opts_t *rats_verifiers_opts[RATS_VERIFIER_TYPE_MAX];
 extern rats_verifier_ctx_t *rats_verifiers_ctx[RATS_VERIFIER_TYPE_MAX];
 extern unsigned int rats_verifier_nums;

--- a/verifiers/internal/rats_verifier_select.c
+++ b/verifiers/internal/rats_verifier_select.c
@@ -25,13 +25,13 @@ static rats_verifier_err_t init_rats_verifier(rats_core_context_t *ctx,
 	return RATS_VERIFIER_ERR_NONE;
 }
 
-rats_verifier_err_t rats_verifier_select(rats_core_context_t *ctx, const char *name)
+rats_verifier_err_t rats_verifier_select(rats_core_context_t *ctx, const char *verifier_type)
 {
-	RATS_DEBUG("selecting the rats verifier '%s' ...\n", name);
+	RATS_DEBUG("selecting the rats verifier of type '%s' ...\n", verifier_type);
 
 	rats_verifier_ctx_t *verifier_ctx = NULL;
 	for (unsigned int i = 0; i < rats_verifier_nums; ++i) {
-		if (name && strcmp(name, rats_verifiers_ctx[i]->opts->name))
+		if (verifier_type && strcmp(verifier_type, rats_verifiers_ctx[i]->opts->type))
 			continue;
 
 		verifier_ctx = (rats_verifier_ctx_t *)malloc(sizeof(*verifier_ctx));
@@ -48,10 +48,10 @@ rats_verifier_err_t rats_verifier_select(rats_core_context_t *ctx, const char *n
 	}
 
 	if (!verifier_ctx) {
-		if (!name)
-			RATS_ERR("failed to select an rats verifier\n");
+		if (!verifier_type)
+			RATS_ERR("failed to select a rats verifier\n");
 		else
-			RATS_ERR("failed to select the rats verifier '%s'\n", name);
+			RATS_ERR("failed to select the rats verifier of type '%s'\n", verifier_type);
 
 		return RATS_VERIFIER_ERR_INVALID;
 	}

--- a/verifiers/internal/rats_verifier_select.c
+++ b/verifiers/internal/rats_verifier_select.c
@@ -25,7 +25,45 @@ static rats_verifier_err_t init_rats_verifier(rats_core_context_t *ctx,
 	return RATS_VERIFIER_ERR_NONE;
 }
 
-rats_verifier_err_t rats_verifier_select(rats_core_context_t *ctx, const char *verifier_type)
+rats_verifier_err_t rats_verifier_select(rats_core_context_t *ctx, const char *name)
+{
+	RATS_DEBUG("selecting the rats verifier of name '%s' ...\n", name);
+
+	rats_verifier_ctx_t *verifier_ctx = NULL;
+	for (unsigned int i = 0; i < rats_verifier_nums; ++i) {
+		if (name && strcmp(name, rats_verifiers_ctx[i]->opts->name))
+			continue;
+
+		verifier_ctx = (rats_verifier_ctx_t *)malloc(sizeof(*verifier_ctx));
+		if (!verifier_ctx)
+			return RATS_VERIFIER_ERR_NO_MEM;
+
+		memcpy(verifier_ctx, rats_verifiers_ctx[i], sizeof(*verifier_ctx));
+
+		if (init_rats_verifier(ctx, verifier_ctx) == RATS_VERIFIER_ERR_NONE)
+			break;
+
+		free(verifier_ctx);
+		verifier_ctx = NULL;
+	}
+
+	if (!verifier_ctx) {
+		if (!name)
+			RATS_ERR("failed to select a rats verifier\n");
+		else
+			RATS_ERR("failed to select the rats verifier of name '%s'\n", name);
+
+		return RATS_VERIFIER_ERR_INVALID;
+	}
+
+	ctx->verifier = verifier_ctx;
+
+	RATS_INFO("the rats verifier '%s' selected\n", ctx->verifier->opts->name);
+
+	return RATS_VERIFIER_ERR_NONE;
+}
+
+rats_verifier_err_t rats_verifier_select_by_type(rats_core_context_t *ctx, const char *verifier_type)
 {
 	RATS_DEBUG("selecting the rats verifier of type '%s' ...\n", verifier_type);
 


### PR DESCRIPTION
Dear Librats developers,

The selector of the verifiers wrongly uses the name (instead of the type) for selecting a verifier based on the evidence type.

The issue appears when using SGX, where the attester and verifier names differ (sgx_ecdsa and sgx_ecdsa_qve, respectively).

This pull request addresses this issue by comparing the type of evidence, which works in scenarios where the attester and verifier have different names.

Cheers!