### PR TITLE
attesters/sev-snp: fix build erro on newer linux kernel

### DIFF
--- a/attesters/sev-snp/collect_evidence.c
+++ b/attesters/sev-snp/collect_evidence.c
@@ -52,8 +52,13 @@ static int snp_get_report(const uint8_t *data, size_t data_size, snp_attestation
 
 	/* Issue the guest request IOCTL */
 	if (ioctl(fd, SNP_GET_REPORT, &guest_req) == -1) {
+#ifdef SNP_GUEST_FW_ERR_MASK
+		RATS_ERR("failed to issue SNP_GET_REPORT ioctl, exit info: %llu\n",
+			 guest_req.exitinfo2);
+#else
 		RATS_ERR("failed to issue SNP_GET_REPORT ioctl, firmware error %llu\n",
 			 guest_req.fw_err);
+#endif
 		goto out_close;
 	}
 


### PR DESCRIPTION
In the recent linux kernel sev-guest driver, a breaking change was introduced, causing a field names of the snp_guest_request_ioctl structure changed.

Refer to https://github.com/torvalds/linux/commit/0144e3b85d7b42e8a4cda991c0e81f131897457a