### PR TITLE
verifiers: generate built-in claims from quotes

### DIFF
--- a/attesters/sev-snp/collect_evidence.c
+++ b/attesters/sev-snp/collect_evidence.c
@@ -102,7 +102,7 @@ rats_attester_err_t sev_snp_collect_evidence(rats_attester_ctx_t *ctx,
 	snprintf(evidence->type, sizeof(evidence->type), "sev_snp");
 
 	rats_attester_err_t err = sev_snp_get_vcek_der(report.chip_id, sizeof(report.chip_id),
-						       &report.platform_version, snp_report);
+						       &report.current_tcb, snp_report);
 	if (err != RATS_ATTESTER_ERR_NONE) {
 		return err;
 	}

--- a/attesters/sev-snp/sev_snp.h
+++ b/attesters/sev-snp/sev_snp.h
@@ -48,7 +48,7 @@ typedef struct snp_attestation_report {
 	uint8_t image_id[16]; /* 0x020 */
 	uint32_t vmpl; /* 0x030 */
 	uint32_t signature_algo; /* 0x034 */
-	snp_tcb_version_t platform_version; /* 0x038 */
+	snp_tcb_version_t current_tcb; /* 0x038 */
 	uint64_t platform_info; /* 0x040 */
 	uint32_t flags; /* 0x048 */
 	uint32_t reserved0; /* 0x04C */

--- a/core/claim.c
+++ b/core/claim.c
@@ -25,9 +25,9 @@ void free_claims_list(claim_t *claims, size_t claims_length)
 	free(claims);
 }
 
-int librats_add_claim(claim_t *claim, const void *name, size_t name_size, const void *value,
-		      size_t value_size)
+int librats_add_claim(claim_t *claim, const char *name, const void *value, size_t value_size)
 {
+	size_t name_size = strlen(name) + 1;
 	claim->name = (char *)malloc(name_size);
 	if (claim->name == NULL)
 		return 1;

--- a/crypto_wrappers/api/crypto_wrapper_verify_certificate_extension.c
+++ b/crypto_wrappers/api/crypto_wrapper_verify_certificate_extension.c
@@ -13,14 +13,6 @@
 #include "internal/verifier.h"
 #include "internal/dice.h"
 
-#include <librats/csv.h>
-// clang-format off
-#ifdef SGX
-#include "sgx_report.h"
-#endif
-#include "sgx_quote_3.h"
-// clang-format on
-
 crypto_wrapper_err_t
 crypto_wrapper_verify_evidence(crypto_wrapper_ctx_t *crypto_ctx, attestation_evidence_t *evidence,
 			       uint8_t *hash, uint32_t hash_len,

--- a/include/librats/claim.h
+++ b/include/librats/claim.h
@@ -12,6 +12,89 @@
 #include <librats/err.h>
 #include <librats/log.h>
 
+/* Common built-in claims */
+#define BUILT_IN_CLAIM_COMMON_QUOTE	 "common_quote"
+#define BUILT_IN_CLAIM_COMMON_QUOTE_TYPE "common_quote_type"
+
+/* SGX built-in claims */
+/* Refer to: https://github.com/intel/linux-sgx/blob/a1eeccba5a72b3b9b342569d2cc469ece106d3e9/common/inc/sgx_report.h#L93-L111 */
+/* Security Version of the CPU */
+#define BUILT_IN_CLAIM_SGX_CPU_SVN "sgx_cpu_svn"
+/* ISV assigned Extended Product ID */
+#define BUILT_IN_CLAIM_SGX_ISV_EXT_PROD_ID "sgx_isv_ext_prod_id"
+/* Any special Capabilities the Enclave possess */
+#define BUILT_IN_CLAIM_SGX_ATTRIBUTES "sgx_attributes"
+/* The value of the enclave's ENCLAVE measurement */
+#define BUILT_IN_CLAIM_SGX_MR_ENCLAVE "sgx_mr_enclave"
+/* The value of the enclave's SIGNER measurement */
+#define BUILT_IN_CLAIM_SGX_MR_SIGNER "sgx_mr_signer"
+/* CONFIGID */
+#define BUILT_IN_CLAIM_SGX_CONFIG_ID "sgx_config_id"
+/* Product ID of the Enclave */
+#define BUILT_IN_CLAIM_SGX_ISV_PROD_ID "sgx_isv_prod_id"
+/* Security Version of the Enclave */
+#define BUILT_IN_CLAIM_SGX_ISV_SVN "sgx_isv_svn"
+/* CONFIGSVN */
+#define BUILT_IN_CLAIM_SGX_CONFIG_SVN "sgx_config_svn"
+/* ISV assigned Family ID */
+#define BUILT_IN_CLAIM_SGX_ISV_FAMILY_ID "sgx_isv_family_id"
+
+/* TDX built-in claims */
+/* Refer to: https://github.com/intel/linux-sgx/blob/a1eeccba5a72b3b9b342569d2cc469ece106d3e9/common/inc/sgx_report.h#L93-L111 */
+/// TEE_TCB_SVN Array
+#define BUILT_IN_CLAIM_TDX_TEE_TCB_SVN "tdx_tee_tcb_svn"
+/// Measurement of the SEAM module
+#define BUILT_IN_CLAIM_TDX_MR_SEAM "tdx_mr_seam"
+/// Measurement of a 3rd party SEAM module’s signer (SHA384 hash). The value is 0’ed for Intel SEAM module
+#define BUILT_IN_CLAIM_TDX_MRSIGNER_SEAM "tdx_mrsigner_seam"
+/// MBZ: TDX 1.0
+#define BUILT_IN_CLAIM_TDX_SEAM_ATTRIBUTES "tdx_seam_attributes"
+/// TD's attributes
+#define BUILT_IN_CLAIM_TDX_TD_ATTRIBUTES "tdx_td_attributes"
+/// TD's XFAM
+#define BUILT_IN_CLAIM_TDX_XFAM "tdx_xfam"
+/// Measurement of the initial contents of the TD
+#define BUILT_IN_CLAIM_TDX_MR_TD "tdx_mr_td"
+/// Software defined ID for non-owner-defined configuration on the guest TD. e.g., runtime or OS configuration
+#define BUILT_IN_CLAIM_TDX_MR_CONFIG_ID "tdx_mr_config_id"
+/// Software defined ID for the guest TD's owner
+#define BUILT_IN_CLAIM_TDX_MR_OWNER "tdx_mr_owner"
+/// Software defined ID for owner-defined configuration of the guest TD, e.g., specific to the workload rather than the runtime or OS
+#define BUILT_IN_CLAIM_TDX_MR_OWNER_CONFIG "tdx_mr_owner_config"
+/// Array of 4(TDX1: NUM_RTMRS is 4) runtime extendable measurement registers
+#define BUILT_IN_CLAIM_TDX_RT_MR0 "tdx_rt_mr0"
+#define BUILT_IN_CLAIM_TDX_RT_MR1 "tdx_rt_mr1"
+#define BUILT_IN_CLAIM_TDX_RT_MR2 "tdx_rt_mr2"
+#define BUILT_IN_CLAIM_TDX_RT_MR3 "tdx_rt_mr3"
+
+/* sev-snp built-in claims */
+#define BUILT_IN_CLAIM_SEV_SNP_GUEST_SVN     "sev_snp_guest_svn" /* 0x004 */
+#define BUILT_IN_CLAIM_SEV_SNP_POLICY	     "sev_snp_policy" /* 0x008 */
+#define BUILT_IN_CLAIM_SEV_SNP_FAMILY_ID     "sev_snp_family_id" /* 0x010 */
+#define BUILT_IN_CLAIM_SEV_SNP_IMAGE_ID	     "sev_snp_image_id" /* 0x020 */
+#define BUILT_IN_CLAIM_SEV_SNP_VMPL	     "sev_snp_vmpl" /* 0x030 */
+#define BUILT_IN_CLAIM_SEV_SNP_CURRENT_TCB   "sev_snp_current_tcb" /* 0x038 */
+#define BUILT_IN_CLAIM_SEV_SNP_PLATFORM_INFO "sev_snp_platform_info" /* 0x040 */
+#define BUILT_IN_CLAIM_SEV_SNP_MEASUREMENT   "sev_snp_measurement" /* 0x090 */
+#define BUILT_IN_CLAIM_SEV_SNP_HOST_DATA     "sev_snp_host_data" /* 0x0C0 */
+#define BUILT_IN_CLAIM_SEV_SNP_ID_KEY_DIGEST "sev_snp_id_key_digest" /* 0x0E0 */
+#define BUILT_IN_CLAIM_SEV_SNP_REPORT_ID     "sev_snp_report_id" /* 0x140 */
+#define BUILT_IN_CLAIM_SEV_SNP_REPORT_ID_MA  "sev_snp_report_id_ma" /* 0x160 */
+#define BUILT_IN_CLAIM_SEV_SNP_REPORTED_TCB  "sev_snp_reported_tcb" /* 0x180 */
+#define BUILT_IN_CLAIM_SEV_SNP_CHIP_ID	     "sev_snp_chip_id" /* 0x1A0 */
+
+/* csv built-in claims */
+#define BUILT_IN_CLAIM_CSV_USER_PUBKEY_DIGEST "csv_user_pubkey_digest"
+#define BUILT_IN_CLAIM_CSV_VM_ID	      "csv_vm_id"
+#define BUILT_IN_CLAIM_CSV_VM_VERSION	      "csv_vm_version"
+#define BUILT_IN_CLAIM_CSV_USER_DATA	      "csv_user_data"
+#define BUILT_IN_CLAIM_CSV_MNONCE	      "csv_mnonce"
+#define BUILT_IN_CLAIM_CSV_MEASURE	      "csv_measure"
+#define BUILT_IN_CLAIM_CSV_POLICY	      "csv_policy"
+#define BUILT_IN_CLAIM_CSV_SIG_USAGE	      "csv_sig_usage"
+#define BUILT_IN_CLAIM_CSV_SIG_ALGO	      "csv_sig_algo"
+#define BUILT_IN_CLAIM_CSV_CHIP_ID	      "csv_chip_id"
+
 /**
  * Claims struct used for claims parameters.
  */
@@ -23,8 +106,7 @@ struct claim {
 } __attribute__((packed));
 
 void free_claims_list(claim_t *claims, size_t claims_length);
-int librats_add_claim(claim_t *claim, const void *name, size_t name_size, const void *value,
-		      size_t value_size);
+int librats_add_claim(claim_t *claim, const char *name, const void *value, size_t value_size);
 
 /* This macro checks whether the expression argument evaluates to RATS_ERR_NONE */
 #define CLAIM_CHECK(EXPRESSION)                           \

--- a/verifiers/tdx-ecdsa/tdx-ecdsa.h
+++ b/verifiers/tdx-ecdsa/tdx-ecdsa.h
@@ -29,16 +29,16 @@ typedef struct {
 
 typedef struct {
 	uint8_t tee_tcb_svn[16];
-	uint8_t mrseam[RATS_SHA384_HASH_SIZE];
+	uint8_t mr_seam[RATS_SHA384_HASH_SIZE];
 	uint8_t mrsigner_seam[RATS_SHA384_HASH_SIZE];
 	uint8_t seam_attributes[8];
 	uint8_t td_attributes[8];
 	uint8_t xfam[8];
-	uint8_t mrtd[RATS_SHA384_HASH_SIZE];
-	uint8_t mrconfig_id[RATS_SHA384_HASH_SIZE];
-	uint8_t mrowner[RATS_SHA384_HASH_SIZE];
-	uint8_t mrowner_config[RATS_SHA384_HASH_SIZE];
-	uint8_t rtmr[TDX_NUM_RTMRS][RATS_SHA384_HASH_SIZE];
+	uint8_t mr_td[RATS_SHA384_HASH_SIZE];
+	uint8_t mr_config_id[RATS_SHA384_HASH_SIZE];
+	uint8_t mr_owner[RATS_SHA384_HASH_SIZE];
+	uint8_t mr_owner_config[RATS_SHA384_HASH_SIZE];
+	uint8_t rt_mr[TDX_NUM_RTMRS][RATS_SHA384_HASH_SIZE];
 	uint8_t report_data[64];
 } __attribute__((packed)) tdx_report_body_t;
 


### PR DESCRIPTION
# Summary

In order to simplify the process of matching of Attestation Policy in user code, and to avoid user code dependencies on TEE-specific headers files / structs definitions, we convert quotes into built-in claims. These claims will be checked by user's verifier callback (verify_claims_callback) along with the user-defined claims.

Currently SGX, TDX, SEV-SNP, CSV verifiers are supported.

For built-in claims, they are:

- `common_quote_type`, `common_quote`
- `tdx_*`
- `sgx_*`
- `sev_snp_*`
- `csv_*`

# Break changes
Note that some break changes are interduced in this commit:

The old claim name in tdx verifier
```c
    #define TDX_CLAIM_RTMR0 "rtmr0"
    #define TDX_CLAIM_RTMR1 "rtmr1"
    #define TDX_CLAIM_RTMR2 "rtmr2"
    #define TDX_CLAIM_RTMR3 "rtmr3"
```
are renamed to "tdx_rtmr0", "tdx_rtmr1", "tdx_rtmr2", "tdx_rtmr3".

# Example

Here is a example of claims (both built-in claims and custom claims) in SGX mode
<details>
<summary>The output of samples/cert-app</summary>

```text
+ ./cert-app -C claim_0:value_0 --log-level DEBUG -k
    - Welcome to librats sample cert-app program for Intel SGX
Success to load enclave with enclave id 2
The flag no_privkey is true. We will let librats to generate random key pairs.

Generate certificate with librats now ...
[DEBUG] rats_attester_init()@L64: called, conf 0x7fbd53d6f750
[DEBUG] libattester_null_init()@L41: called
[DEBUG] rats_attester_register()@L20: registering the rats attester 'nullattester' ...
[INFO] rats_attester_register()@L100: the rats attester 'nullattester' registered with type 'nullattester'
[DEBUG] nullattester_pre_init()@L12: called
[DEBUG] libattester_sgx_la_init()@L36: called
[DEBUG] rats_attester_register()@L20: registering the rats attester 'sgx_la' ...
[INFO] rats_attester_register()@L100: the rats attester 'sgx_la' registered with type 'sgx_la'
[DEBUG] sgx_la_attester_pre_init()@L12: called
[DEBUG] libattester_sgx_ecdsa_init()@L41: called
[DEBUG] rats_attester_register()@L20: registering the rats attester 'sgx_ecdsa' ...
[INFO] rats_attester_register()@L100: the rats attester 'sgx_ecdsa' registered with type 'sgx_ecdsa'
[DEBUG] sgx_ecdsa_attester_pre_init()@L12: called
[DEBUG] rats_attester_select()@L31: selecting the rats attester 'sgx_ecdsa'...
[DEBUG] init_rats_attester()@L17: called rats core ctx: 0x7fbd53d6ae00 rats attester ctx: 0x7fbd50382500
[DEBUG] sgx_ecdsa_attester_init()@L14: ctx 0x7fbd50382500
[INFO] rats_attester_select()@L62: the rats attester 'sgx_ecdsa' selected
[DEBUG] rats_crypto_wrapper_init()@L174: called, conf 0x7fbd53d6f750
[DEBUG] libcrypto_wrapper_nullcrypto_init()@L51: called
[DEBUG] crypto_wrapper_register()@L18: registering the crypto wrapper 'nullcrypto' ...
[INFO] crypto_wrapper_register()@L39: the crypto wrapper 'nullcrypto' registered
[DEBUG] nullcrypto_pre_init()@L12: called
[DEBUG] libcrypto_wrapper_openssl_init()@L48: called
[DEBUG] crypto_wrapper_register()@L18: registering the crypto wrapper 'openssl' ...
[INFO] crypto_wrapper_register()@L39: the crypto wrapper 'openssl' registered
[DEBUG] openssl_pre_init()@L12: called
[DEBUG] crypto_wrapper_select()@L27: selecting the crypto wrapper '(null)' ...
[DEBUG] openssl_init()@L16: ctx 0x7fbd503826f0
[INFO] crypto_wrapper_select()@L59: the crypto wrapper 'openssl' selected
[DEBUG] librats_get_attestation_certificate()@L78: here from log
[DEBUG] openssl_gen_privkey()@L23: ctx 0x7fbd503826f0, key_algo 1, privkey 0x7fbd53d6f830, privkey_len 0x7fbd53d6f838
[DEBUG] openssl_gen_privkey()@L90: private key (241-byte) in PEM format
[DEBUG] openssl_get_pubkey_hash()@L19: ctx 0x7fbd503826f0, hash_algo 1, hash 0x7fbd53d6acb0
[DEBUG] openssl_gen_hash()@L14: ctx 0x7fbd503826f0, hash_algo 1, data 0x7fbd50382c70, size 91 hash 0x7fbd53d6acb0
[DEBUG] librats_get_attestation_certificate()@L110: fill evidence user-data field with sha256 of claims_buffer
[DEBUG] openssl_gen_hash()@L14: ctx 0x7fbd503826f0, hash_algo 1, data 0x7fbd50382970, size 67 hash 0x7fbd53d6acb0
[DEBUG] librats_get_attestation_certificate()@L124: evidence user-data field [32] 4193493b0bf063ec312bc9ccd607b44b...
[DEBUG] sgx_ecdsa_collect_evidence()@L62: ctx 0x7fbd50382500, evidence 0x7fbd53d6cee0, hash 0x7fbd53d6acb0
[DEBUG] sgx_ecdsa_collect_evidence()@L127: Succeed to generate the quote!
[DEBUG] librats_get_attestation_certificate()@L134: evidence.type: 'sgx_ecdsa'
[DEBUG] evidence_get_raw_as_ref()@L70: evidence raw data [4734] 030002000000000009000e00939a7233...
[DEBUG] librats_get_attestation_certificate()@L151: evidence buffer size: 4810
[DEBUG] sgx_ecdsa_collect_endorsements()@L27: ctx 0x7fbd50382500, evidence 0x7fbd53d6cee0, endorsements 0x7fbd53d6ad80
[DEBUG] sgx_ecdsa_collect_endorsements()@L38: rats_ocall_tee_qv_get_collateral() succeeded. collateral_untrusted: 0x55ff670658b0
[DEBUG] sgx_ecdsa_collect_endorsements()@L89: version: 3, pck_crl_issuer_chain_size: 1905, root_ca_crl_size: 587, pck_crl_size: 3657, tcb_info_issuer_chain_size: 1893, tcb_info_size: 1540, qe_identity_issuer_chain_size: 1893, qe_identity_size: 1012
[DEBUG] librats_get_attestation_certificate()@L177: endorsements buffer size: 12517
[DEBUG] openssl_gen_cert()@L127: ctx: 0x7fbd503826f0, hash_algo: 1, cert_info: 0x7fbd53d6aea0
[DEBUG] openssl_gen_cert()@L208: self-signing certificate generated
[DEBUG] openssl_cleanup()@L14: ctx 0x7fbd503826f0
[DEBUG] sgx_ecdsa_attester_cleanup()@L12: called
----------------------------------------
The privkey generated by librats (PEM format):
privkey len: 241
privkey: 
-----BEGIN PRIVATE KEY-----
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgQRivxGEX1HWKJIsq
B/PNGPQJP7pPZofnsPcyXmpmceChRANCAASICI7Ig6czmvBQo/L4Sme8VhK/SJS5
V5l8IuPpF/+ju6+fWseaw9+S5oThYEleYPbugkQ8YvUPQ0xutV+MzzYV
-----END PRIVATE KEY-----
----------------------------------------
Certificate generation: SUCCESS
Path to the generated certificate: /tmp/cert.der

Verify certificate with librats now ...
[DEBUG] rats_verifier_init()@L127: called, conf 0x7fbd53d6f800
[DEBUG] libverifier_null_init()@L39: called
[DEBUG] rats_verifier_register()@L39: registering the rats verifier 'nullverifier' ...
[INFO] rats_verifier_register()@L69: the rats verifier 'nullverifier' registered with type 'nullverifier'
[DEBUG] nullverifier_pre_init()@L12: called
[DEBUG] libverifier_sgx_la_init()@L38: called
[DEBUG] rats_verifier_register()@L39: registering the rats verifier 'sgx_la' ...
[INFO] rats_verifier_register()@L69: the rats verifier 'sgx_la' registered with type 'sgx_la'
[DEBUG] sgx_la_verifier_pre_init()@L12: called
[DEBUG] libverifier_sgx_ecdsa_qve_init()@L39: called
[DEBUG] rats_verifier_register()@L39: registering the rats verifier 'sgx_ecdsa_qve' ...
[INFO] rats_verifier_register()@L69: the rats verifier 'sgx_ecdsa_qve' registered with type 'sgx_ecdsa'
[DEBUG] sgx_ecdsa_verifier_pre_init()@L12: called
[DEBUG] rats_verifier_select()@L30: selecting the rats verifier of name '(null)' ...
[DEBUG] init_rats_verifier()@L16: init rats verifier rats_core_context: 0x7fbd53d6f740
[DEBUG] sgx_ecdsa_verifier_init()@L14: ctx 0x7fbd50384a20
[INFO] rats_verifier_select()@L61: the rats verifier 'sgx_ecdsa_qve' selected
[DEBUG] rats_crypto_wrapper_init()@L174: called, conf 0x7fbd53d6f800
[DEBUG] crypto_wrapper_select()@L27: selecting the crypto wrapper '(null)' ...
[DEBUG] openssl_init()@L16: ctx 0x7fbd50384a70
[INFO] crypto_wrapper_select()@L59: the crypto wrapper 'openssl' selected
[DEBUG] openssl_verify_cert()@L76: ctx: 0x7fbd50384a70, certificate: 0x7fbd5037a230, certificate_size 17780
[DEBUG] crypto_wrapper_verify_certificate_extension()@L73: crypto_ctx: 0x7fbd50384a70, pubkey_buffer: 0x7fbd53d6f5d0, pubkey_buffer_size: 91, evidence_buffer: 0x7fbd503ab9d0, evidence_buffer_size: 4810, endorsements_buffer: 0x7fbd503accb0, endorsements_buffer_size: 12517
[DEBUG] evidence_from_raw()@L82: evidence raw data [4734] 030002000000000009000e00939a7233...
[DEBUG] crypto_wrapper_verify_certificate_extension()@L103: evidence->type: 'sgx_ecdsa'
[DEBUG] crypto_wrapper_verify_certificate_extension()@L107: has_endorsements: true
[DEBUG] crypto_wrapper_verify_certificate_extension()@L124: check evidence userdata field with sha256 of claims_buffer
[DEBUG] openssl_gen_hash()@L14: ctx 0x7fbd50384a70, hash_algo 1, data 0x7fbd503b11d0, size 67 hash 0x7fbd53d6f4d0
[DEBUG] crypto_wrapper_verify_certificate_extension()@L145: sha256 of claims_buffer [32] 4193493b0bf063ec312bc9ccd607b44b...
[DEBUG] crypto_wrapper_verify_evidence()@L22: crypto_wrapper_verify_evidence() called with evidence type: 'sgx_ecdsa'
[DEBUG] sgx_ecdsa_verify_evidence()@L374: ctx 0x7fbd50384a20, evidence 0x7fbd53d6cca0, hash 0x7fbd53d6f4d0
[DEBUG] sgx_ecdsa_verify_evidence()@L381: quote size is 4734, quote signature_data_len is 4298
[INFO] ecdsa_verify_evidence()@L77: sgx qv gets quote supplemental data size successfully.
[INFO] ecdsa_verify_evidence()@L131: quote verification completed. quote_verification_result: 0, collateral_expiration_status: 0
[INFO] ecdsa_verify_evidence()@L148: verify QvE report and identity successfully.
[INFO] ecdsa_verify_evidence()@L163: verification completed successfully.
[DEBUG] crypto_wrapper_verify_certificate_extension()@L184: custom_claims 0x7fbd503b16b0, claims_size 1
[DEBUG] crypto_wrapper_verify_certificate_extension()@L187: custom_claims[0] -> name: 'claim_0' value_size: 7
[DEBUG] crypto_wrapper_verify_certificate_extension()@L192: check pubkey hash. pubkey_hash: 0x7fbd53d6f4f0, pubkey_hash_algo: 1
[DEBUG] openssl_gen_hash()@L14: ctx 0x7fbd50384a70, hash_algo 1, data 0x7fbd53d6f5d0, size 91 hash 0x7fbd53d6f530
[DEBUG] crypto_wrapper_verify_certificate_extension()@L213: The hash of public key [32] f461c5eb30b7b400...
----------------------------------------
verify_callback called, claims 0x7fbd503b14f0, claims_size 13, args 0x7ffd3669fe20
claims[0] -> name: 'common_quote' value_size: 4734 value: (hex)030002000000000009000E00939A7233F79C4CA9940A0DB3957F060709529494683F259A3982EEF04C93E146000000000B0B100FFFFF0000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000E700000000000000914BFE9A0AC86E7C6FD56E9A47E787B5308EB294756FFC9ADE0394B8388CDF45000000000000000000000000000000000000000000000000000000000000000083D719E77DEACA1470F6BAF62A4D774303C899DB69020F9C70EE1DFC08C7CE9E000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004193493B0BF063EC312BC9CCD607B44B3975620DDBB2A8C43F11F6A9C7A1EB320000000000000000000000000000000000000000000000000000000000000000CA100000BBC49A3048AEB670521D348FB0E5B342145FEB0E7D7712AB947727086629F6A7E82E84215F25956EA0BC15C2D7895BEE85B78DE00A42214DDA59F26B6CDEFFC282671663C5AB60CBF1091D813B0101DE380B935F5FAC39493E8E7EEF75A36309277842DE2682F19ECFD08128AC91C3252D9BEB15D29D36149B543C9B5F4D539B0B0B100FFFFF0000000000000000000000000000000000000000000000000000000000000000000000000000000000001500000000000000E700000000000000192AA50CE1C0CEF03CCF89E7B5B16B0D7978F5C2B1EDCF774D87702E8154D8BF00000000000000000000000000000000000000000000000000000000000000008C4F5775D796503E96137F77C68A829A0056AC8DED70140B081B094490C57BFF00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000093DF15CEED99D0717037A38F8C776755B78B841109B86B1D9021B79F3F22E170000000000000000000000000000000000000000000000000000000000000000CFC84BA42E0184883FE3DD8E86E8B05EB4C16E2BF06FF9139BD0CAE14FC5DE7C2CA4589C7AA820F2ADC1A946CB75EE4FC2217D8B45955A68A61BA4499A0DCDA22000000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F0500620E00002D2D2D2D2D424547494E2043455254494649434154452D2D2D2D2D0A4D494945387A4343424A69674177494241674955564B7134536D35644E356A496A6C41386B7947756836677064545977436759494B6F5A497A6A3045417749770A634445694D434147413155454177775A535735305A577767553064594946424453794251624746305A6D397962534244515445614D42674741315545436777520A535735305A577767513239796347397959585270623234784644415342674E564241634D43314E68626E526849454E7359584A684D51737743515944565151490A44414A445154454C4D416B474131554542684D4356564D774868634E4D6A4D774E5445774D4445314E7A49795768634E4D7A41774E5445774D4445314E7A49790A576A42774D534977494159445651514444426C4A626E526C624342545231676755454E4C49454E6C636E52705A6D6C6A5958526C4D526F77474159445651514B0A4442464A626E526C6243424462334A7762334A6864476C76626A45554D424947413155454277774C553246756447456751327868636D4578437A414A42674E560A4241674D416B4E424D517377435159445651514745774A56557A425A4D424D4742797147534D34394167454743437147534D343941774548413049414246506D0A4B787738663064513535363077542F553238306175504366796E582F635247537A5A6F744251366D33624E6249517A784A44536677626235713846357343656A0A4F77346A646346395179622B2B3677626771716A67674D4F4D494944436A416642674E5648534D4547444157674253566231334E765276683655424A796454300A4D383442567776655644427242674E56485238455A4442694D47436758714263686C706F64485277637A6F764C32467761533530636E567A6447566B633256790A646D6C6A5A584D75615735305A577775593239744C334E6E6543396A5A584A3061575A7059324630615739754C33597A4C33426A61324E796244396A595431770A624746305A6D397962535A6C626D4E765A476C755A7A316B5A584977485159445652304F4242594546444F6D524A4368557163686D57415041574A58324361510A6C4546644D41344741315564447745422F775145417749477744414D42674E5648524D4241663845416A41414D4949434F77594A4B6F5A496876684E415130420A424949434C444343416967774867594B4B6F5A496876684E4151304241515151686D6A2F3854786C49654A505535516552745175636A434341575547436971470A534962345451454E41514977676746564D42414743797147534962345451454E415149424167454C4D42414743797147534962345451454E415149434167454C0A4D42414743797147534962345451454E41514944416745444D42414743797147534962345451454E41514945416745444D42454743797147534962345451454E0A41514946416749412F7A415242677371686B69472B4530424451454342674943415038774541594C4B6F5A496876684E4151304241676343415141774541594C0A4B6F5A496876684E4151304241676743415141774541594C4B6F5A496876684E4151304241676B43415141774541594C4B6F5A496876684E4151304241676F430A415141774541594C4B6F5A496876684E4151304241677343415141774541594C4B6F5A496876684E4151304241677743415141774541594C4B6F5A496876684E0A4151304241673043415141774541594C4B6F5A496876684E4151304241673443415141774541594C4B6F5A496876684E4151304241673843415141774541594C0A4B6F5A496876684E4151304241684143415141774541594C4B6F5A496876684E4151304241684543415130774877594C4B6F5A496876684E41513042416849450A4541734C4177502F2F7741414141414141414141414141774541594B4B6F5A496876684E4151304241775143414141774641594B4B6F5A496876684E415130420A4241514741474271414141414D41384743697147534962345451454E4151554B415145774867594B4B6F5A496876684E41513042426751515443364C646F79350A4838724A5164374F616667474544424542676F71686B69472B453042445145484D4459774541594C4B6F5A496876684E4151304242774542416638774541594C0A4B6F5A496876684E4151304242774942416638774541594C4B6F5A496876684E4151304242774D4241663877436759494B6F5A497A6A304541774944535141770A52674968414A6C5374356C577A725951366F464367534B51353971374A6C6A64774E324F46744C51717675763133772B41694541752B49334E455954326258770A75445036795A492F50396971516B3964426D62432B7A566F2B6575355638453D0A2D2D2D2D2D454E442043455254494649434154452D2D2D2D2D0A2D2D2D2D2D424547494E2043455254494649434154452D2D2D2D2D0A4D4949436C6A4343416A32674177494241674956414A567658633239472B487051456E4A3150517A7A674658433935554D416F4743437147534D343942414D430A4D476778476A415942674E5642414D4D45556C756447567349464E48574342536232393049454E424D526F77474159445651514B4442464A626E526C624342440A62334A7762334A6864476C76626A45554D424947413155454277774C553246756447456751327868636D4578437A414A42674E564241674D416B4E424D5173770A435159445651514745774A56557A4165467730784F4441314D6A45784D4455774D5442614677307A4D7A41314D6A45784D4455774D5442614D484178496A41670A42674E5642414D4D47556C756447567349464E4857434251513073675547786864475A76636D306751304578476A415942674E5642416F4D45556C75644756730A49454E76636E4276636D4630615739754D5251774567594456515148444174545957353059534244624746795954454C4D416B474131554543417743513045780A437A414A42674E5642415954416C56544D466B77457759484B6F5A497A6A3043415159494B6F5A497A6A304441516344516741454E53422F377432316C58534F0A3243757A7078773734654A423732457944476757357258437478327456544C7136684B6B367A2B5569525A436E71523770734F766771466553786C6D546C4A6C0A65546D693257597A33714F42757A43427544416642674E5648534D4547444157674251695A517A575770303069664F44744A5653763141624F536347724442530A42674E5648523845537A424A4D45656752614244686B466F64485277637A6F764C324E6C636E52705A6D6C6A5958526C63793530636E567A6447566B633256790A646D6C6A5A584D75615735305A577775593239744C306C756447567355306459556D397664454E424C6D526C636A416442674E5648513445466751556C5739640A7A62306234656C4153636E553944504F4156634C336C517744675944565230504151482F42415144416745474D42494741315564457745422F7751494D4159420A4166384341514177436759494B6F5A497A6A30454177494452774177524149675873566B6930772B6936565947573355462F32327561586530594A446A3155650A6E412B546A44316169356343494359623153416D4435786B66545670766F34556F79695359787244574C6D5552344349394E4B7966504E2B0A2D2D2D2D2D454E442043455254494649434154452D2D2D2D2D0A2D2D2D2D2D424547494E2043455254494649434154452D2D2D2D2D0A4D4949436A7A4343416A53674177494241674955496D554D316C71644E496E7A6737535655723951477A6B6E42717777436759494B6F5A497A6A3045417749770A614445614D4267474131554541777752535735305A5777675530645949464A766233516751304578476A415942674E5642416F4D45556C756447567349454E760A636E4276636D4630615739754D5251774567594456515148444174545957353059534244624746795954454C4D416B47413155454341774351304578437A414A0A42674E5642415954416C56544D423458445445344D4455794D5445774E4455784D466F58445451354D54497A4D54497A4E546B314F566F77614445614D4267470A4131554541777752535735305A5777675530645949464A766233516751304578476A415942674E5642416F4D45556C756447567349454E76636E4276636D46300A615739754D5251774567594456515148444174545957353059534244624746795954454C4D416B47413155454341774351304578437A414A42674E56424159540A416C56544D466B77457759484B6F5A497A6A3043415159494B6F5A497A6A3044415163445167414543366E45774D4449595A4F6A2F69505773437A61454B69370A314F694F534C52466857476A626E42564A66566E6B59347533496A6B4459594C304D784F346D717379596A6C42616C54565978465032734A424B357A6C4B4F420A757A43427544416642674E5648534D4547444157674251695A517A575770303069664F44744A5653763141624F5363477244425342674E5648523845537A424A0A4D45656752614244686B466F64485277637A6F764C324E6C636E52705A6D6C6A5958526C63793530636E567A6447566B63325679646D6C6A5A584D75615735300A5A577775593239744C306C756447567355306459556D397664454E424C6D526C636A416442674E564851344546675155496D554D316C71644E496E7A673753560A55723951477A6B6E4271777744675944565230504151482F42415144416745474D42494741315564457745422F7751494D4159424166384341514577436759490A4B6F5A497A6A3045417749445351417752674968414F572F35516B522B533943695344634E6F6F774C7550524C735747662F59693747535839344267775477670A41694541344A306C72486F4D732B586F356F2F7358364F39515778485241765A55474F6452513763767152586171493D0A2D2D2D2D2D454E442043455254494649434154452D2D2D2D2D0A00
claims[1] -> name: 'common_quote_type' value_size: 10 value: (hex)7367785F656364736100
claims[2] -> name: 'sgx_cpu_svn' value_size: 16 value: (hex)0B0B100FFFFF00000000000000000000
claims[3] -> name: 'sgx_isv_ext_prod_id' value_size: 16 value: (hex)00000000000000000000000000000000
claims[4] -> name: 'sgx_attributes' value_size: 16 value: (hex)0500000000000000E700000000000000
claims[5] -> name: 'sgx_mr_enclave' value_size: 32 value: (hex)914BFE9A0AC86E7C6FD56E9A47E787B5308EB294756FFC9ADE0394B8388CDF45
claims[6] -> name: 'sgx_mr_signer' value_size: 32 value: (hex)83D719E77DEACA1470F6BAF62A4D774303C899DB69020F9C70EE1DFC08C7CE9E
claims[7] -> name: 'sgx_config_id' value_size: 64 value: (hex)00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
claims[8] -> name: 'sgx_isv_prod_id' value_size: 2 value: (hex)0000
claims[9] -> name: 'sgx_isv_svn' value_size: 2 value: (hex)0000
claims[10] -> name: 'sgx_config_svn' value_size: 2 value: (hex)0000
claims[11] -> name: 'sgx_isv_family_id' value_size: 16 value: (hex)00000000000000000000000000000000
claims[12] -> name: 'claim_0' value_size: 7 value: 'value_0'
checking for all 1 user-defined custom claims
verify_callback check result:   SUCCESS
----------------------------------------
[DEBUG] openssl_cleanup()@L14: ctx 0x7fbd50384a70
[DEBUG] sgx_ecdsa_verifier_cleanup()@L12: called
Certificate verification:       SUCCESS
```
</details>