### PR TITLE
verifiers: use type instead of name in static init

### DIFF
--- a/core/rats_init.c
+++ b/core/rats_init.c
@@ -161,7 +161,7 @@ rats_verifier_err_t rats_verifier_init(rats_conf_t *conf, rats_core_context_t *c
 		if (choice[0] == '\0')
 			choice = NULL;
 	}
-	err = rats_verifier_select(ctx, choice);
+	err = rats_verifier_select_by_type(ctx, choice);
 	if (err != RATS_VERIFIER_ERR_NONE)
 		goto err_ctx;
 


### PR DESCRIPTION
Dear developers,

Following my previous PR (#82), I realized that the code previously mentioned by @KB5201314 was also causing issues for validation of attestation evidence when using librats in WAMR:

https://github.com/inclavare-containers/librats/blob/42e2d7df63aed8e08d40a13562b4e1573d7c6d8c/core/rats_init.c#L164

Indeed, the second argument, `choice`, is previously assigned to the type of a verifier:

https://github.com/inclavare-containers/librats/blob/42e2d7df63aed8e08d40a13562b4e1573d7c6d8c/core/rats_init.c#L158-L160

Hence, the function call to `rats_verifier_select` must be swapped with `rats_verifier_select_by_type`.

----

For a comprehensive description of the issue: in WAMR, the verifier of type `sgx_ecdsa` is used for quotes verification, but only the `qve` variant is provided. An error is raised during the validation process, as detailed in the logs below.
By requesting the type instead of the name for the verifier, the type `sgx_ecdsa` is recognized for its variant `qve`, which is then provided and working as expected.

> [ERROR] rats_verifier_select()@L54: failed to select the rats verifier of name 'sgx_ecdsa'
> [ERROR] librats_verify_evidence_from_json()@L145: failed to librats_verify_evidence return 0x30000007
> ERROR: Evidence is not trusted, error code: 0x30000007.