### PR TITLE
sgx_ecdsa: set the load_policy at most once

### DIFF
--- a/tee/sgx/untrust/sgx_ecdsa_ocall.c
+++ b/tee/sgx/untrust/sgx_ecdsa_ocall.c
@@ -78,13 +78,15 @@ rats_verifier_err_t rats_ocall_ecdsa_verify_evidence(
 	/* sgx_ecdsa_qve instance re-uses this code and thus we need to distinguish
 	 * it from sgx_ecdsa instance.
 	 */
+	static bool has_load_policy_been_set = false;
 	bool is_sgx_ecdsa_qve = p_qve_report_info != NULL;
-	if (is_sgx_ecdsa_qve) {
+	if (is_sgx_ecdsa_qve && !has_load_policy_been_set) {
 		/* Set enclave load policy of Quote Verification Library before loading the QvE enclave. */
 		dcap_ret = sgx_qv_set_enclave_load_policy(SGX_QL_DEFAULT);
-		if (dcap_ret == SGX_QL_SUCCESS)
+		if (dcap_ret == SGX_QL_SUCCESS) {
+			has_load_policy_been_set = true;
 			RATS_INFO("sgx qv setting for enclave load policy succeeds.\n");
-		else {
+		} else {
 			RATS_ERR("failed to set enclave load policy by sgx qv: %04x\n", dcap_ret);
 			err = SGX_ECDSA_VERIFIER_ERR_CODE((int)dcap_ret);
 			goto errret;


### PR DESCRIPTION
Dear librats developers,

While using WAMR and more specifically the sample of SGX-RA as found [here](https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/samples/sgx-ra), I realized that validating evidence more than once (can be the same, or new evidence) throws the following error in the console:

```
[ERROR] rats_ocall_ecdsa_verify_evidence()@L88: failed to set enclave load policy by sgx qv: e00c
[ERROR] ecdsa_verify_evidence()@L124: rats_ocall_ecdsa_verify_evidence() failed. sgx_status: 0, err: 0xb000e00c, collateral_expiration_status: 0, quote_verification_result: 0
[ERROR] sgx_ecdsa_verify_evidence()@L468: failed to verify ecdsa, cfffffff
[ERROR] librats_verify_evidence_from_json()@L144: failed to librats_verify_evidence return 0xcfffffff
ERROR: Evidence is not trusted, error code: 0xcfffffff.
```

The notable information here is that the error is thrown when calling the function `sgx_qv_set_enclave_load_policy`, which raises the error `0xe00c` (` SGX_QL_UNSUPPORTED_LOADING_POLICY`).

The issue can be reproduced by duplicating the validation calls of the sample ([these ones](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/samples/sgx-ra/wasm-app/main.c#L98-L105)).

After some investigations, I found out that calling `sgx_qv_set_enclave_load_policy` more than once with `SGX_QL_DEFAULT` (=`SGX_QL_PERSISTENT`) as an argument throws this error. So, I would suggest a patch in the verification OCALL that checks whether the load policy has already been set, and if so, don't set it more than once.

This patch solved this issue on my hardware (SGX2-enabled Intel NUC).

Cheers