### PR TITLE
workflow: migrate Dockerfile from rats-tls to librats

### DIFF
--- a/.github/workflows/docker/Dockerfile-compilation-testing-anolis8.6
+++ b/.github/workflows/docker/Dockerfile-compilation-testing-anolis8.6
@@ -1,0 +1,50 @@
+FROM openanolis/anolisos:8.6-x86_64
+
+LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
+
+ENV SGX_SDK_VERSION 2.23
+ENV SGX_SDK_RELEASE_NUMBER 2.23.100.2
+ENV SGX_DCAP_VERSION 1.20
+
+# install some necessary packages
+RUN dnf install -y --nogpgcheck epel-release
+
+RUN dnf clean all && rm -rf /var/cache/dnf && \
+    dnf --enablerepo=PowerTools install -y git wget \
+        make cmake autoconf libtool gcc gcc-c++ \
+        openssl-devel libcurl-devel dnf-utils patch \
+        libcbor-devel
+
+WORKDIR /root
+
+# install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+ENV PATH         /root/.cargo/bin:$PATH
+
+# install LVI binutils for rats-tls build
+RUN wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/as.ld.objdump.r4.tar.gz && \
+    tar -zxvf as.ld.objdump.r4.tar.gz && cp -rf external/toolset/anolis8.6/* /usr/local/bin/ && \
+    rm -rf external && rm -rf as.ld.objdump.r4.tar.gz
+
+# install SGX SDK
+RUN [ ! -f sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin ] && \
+    wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/distro/Anolis86/sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
+    chmod +x sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && echo -e 'n\n\/opt/intel\n' | ./sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
+    source /opt/intel/sgxsdk/environment && \
+    rm -rf sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin
+
+# add repository to package manager
+RUN [ ! -f sgx_rpm_local_repo.tgz ] && \
+    wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/distro/Anolis86/sgx_rpm_local_repo.tgz && \
+    tar zxvf sgx_rpm_local_repo.tgz && \
+    dnf config-manager --add-repo sgx_rpm_local_repo && \
+    dnf makecache && rm -rf sgx_rpm_local_repo.tgz
+
+# install SGX DCAP
+RUN dnf install --nogpgcheck -y libsgx-headers-"$SGX_SDK_VERSION*" \
+        libsgx-dcap-quote-verify-devel-"$SGX_DCAP_VERSION*" \
+        libsgx-dcap-ql-devel-"$SGX_DCAP_VERSION*" \
+        libsgx-dcap-default-qpl-"$SGX_DCAP_VERSION*"
+
+# install tdx
+RUN dnf install --nogpgcheck -y libtdx-attest-devel-"$SGX_DCAP_VERSION*"

--- a/.github/workflows/docker/Dockerfile-compilation-testing-ubuntu20.04
+++ b/.github/workflows/docker/Dockerfile-compilation-testing-ubuntu20.04
@@ -1,0 +1,48 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="Huiting Hou <houhuiting@stu.pku.edu.cn>"
+
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV SGX_SDK_VERSION 2.23
+ENV SGX_SDK_RELEASE_NUMBER 2.23.100.2
+ENV SGX_DCAP_VERSION 1.20
+
+# install some necessary packages
+RUN echo "deb http://cz.archive.ubuntu.com/ubuntu bionic main" >> /etc/apt/sources.list && apt-get update && apt-get install -y libprotobuf10
+
+RUN apt-get update && apt-get install -y make git vim clang-format-9 gcc \
+        pkg-config protobuf-compiler debhelper cmake \
+        wget net-tools curl file gnupg tree libcurl4-openssl-dev \
+        libbinutils libseccomp-dev libssl-dev binutils-dev libprotoc-dev \
+        libcbor-dev
+
+WORKDIR /root
+
+# install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+ENV PATH         /root/.cargo/bin:$PATH
+
+# install LVI binutils for rats-tls build
+RUN wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/as.ld.objdump.r4.tar.gz && \
+    tar -zxvf as.ld.objdump.r4.tar.gz && cp -rf external/toolset/ubuntu20.04/* /usr/local/bin/ && \
+    rm -rf external && rm -rf as.ld.objdump.r4.tar.gz
+
+# install SGX SDK
+RUN [ ! -f sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin ] && \
+    wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/distro/ubuntu20.04-server/sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
+    chmod +x sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && echo -e 'no\n/opt/intel\n' | ./sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
+    rm -f sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin
+
+# add repository to package manager
+RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main" | tee /etc/apt/sources.list.d/intel-sgx.list && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+
+# install SGX DCAP
+RUN apt-get update -y && apt-get install -y libsgx-headers="$SGX_SDK_VERSION*" \
+        libsgx-dcap-quote-verify-dev="$SGX_DCAP_VERSION*" \
+        libsgx-dcap-ql-dev="$SGX_DCAP_VERSION*" \
+        libsgx-dcap-default-qpl="$SGX_DCAP_VERSION*"
+
+# install tdx
+RUN apt-get install -y libtdx-attest-dev="$SGX_DCAP_VERSION*"

--- a/.github/workflows/manually_compilation_testing_image.yml
+++ b/.github/workflows/manually_compilation_testing_image.yml
@@ -1,0 +1,38 @@
+name: Build compilation testing image
+
+# This is a manual trigger.
+on: [workflow_dispatch]
+
+jobs:
+  build-compilation-testing-image:
+    # Run all steps in the compilation testing containers
+    strategy:
+      matrix:
+        os: [anolis8.6, ubuntu20.04]
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Because "Build and push" step `context` field can't be subdir,
+      # we need to copy files needed by dockerfile to root dir of the project
+      - name: Copy context for docker build
+        run: |
+          cp -r .github/workflows/docker .
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.TEST_DOCKER_USERNAME }}
+          password: ${{ secrets.TEST_DOCKER_PASSWORD }}
+
+      - name: Build and push the image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile-compilation-testing-${{ matrix.os }}
+          platforms: linux/amd64
+          push: true
+          tags: runetest/compilation-testing:${{ matrix.os }}


### PR DESCRIPTION
This PR migrate [runetest/compilation-testing](https://hub.docker.com/r/runetest/compilation-testing) image from rats-tls to librats, and update SGX SDK and SGX DCAP to the latest version.
