### PR TITLE
Refactors CMakeLists.txt and makes it more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12.0)
 if(RATS_BUILD_MODE STREQUAL "wasm")
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Emscripten.cmake")
 endif()
@@ -148,7 +148,7 @@ endif()
 
 add_subdirectory(crypto_wrappers)
 
-list(APPEND INCLUDE_DIRS ${LIBCBOR_INC_PATH})
+list(APPEND INCLUDE_DIRS ${LIBCBOR_INC_PATH}) # libcbor is need by core layer only 
 
 include_directories(${INCLUDE_DIRS})
 
@@ -336,9 +336,9 @@ endif()
 # Install lib
 if(NOT WASM)
     install(TARGETS ${RATS_LIB} DESTINATION ${RATS_INSTALL_LIB_PATH})
-    install(DIRECTORY DESTINATION ${RATS_INSTALL_INCLUDE_PATH}/librats)
-    install(FILES ${RATS_INCLUDE_FILES} DESTINATION ${RATS_INSTALL_INCLUDE_PATH}/librats)
+    install(DIRECTORY DESTINATION ${RATS_INSTALL_INCLUDE_PATH})
+    install(FILES ${RATS_INCLUDE_FILES} DESTINATION ${RATS_INSTALL_INCLUDE_PATH})
     if(SGX)
-        install(FILES ${RATS_EDL_FILES} DESTINATION ${RATS_INSTALL_INCLUDE_PATH}/librats/edl)
+        install(FILES ${RATS_EDL_FILES} DESTINATION ${RATS_INSTALL_INCLUDE_PATH}/edl)
     endif()
 endif()

--- a/attesters/csv/CMakeLists.txt
+++ b/attesters/csv/CMakeLists.txt
@@ -1,8 +1,13 @@
 # Project name
 project(attester_csv)
 
+find_package (OpenSSL REQUIRED)
+
+find_package (CURL REQUIRED)
+
 # Set include directory
-set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+set(INCLUDE_DIRS ${INCLUDE_DIRS}
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  )
@@ -25,7 +30,7 @@ set(SOURCES cleanup.c
 
 # Generate library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
-target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto curl)
+target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} OpenSSL::Crypto CURL::libcurl)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
 # Install library

--- a/attesters/sev-snp/CMakeLists.txt
+++ b/attesters/sev-snp/CMakeLists.txt
@@ -7,6 +7,9 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  ${CMAKE_CURRENT_SOURCE_DIR}
                  )
+
+find_package (CURL REQUIRED)
+
 include_directories(${INCLUDE_DIRS})
 
 # Set dependency library directory
@@ -27,7 +30,7 @@ set(SOURCES cleanup.c
 
 # Generate library
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
-    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} curl)
+    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} CURL::libcurl)
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
     # Install library
     install(TARGETS ${PROJECT_NAME}

--- a/attesters/sev/CMakeLists.txt
+++ b/attesters/sev/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Project name
 project(attester_sev)
 
+find_package (OpenSSL REQUIRED)
+
 # Set include directory
 set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
@@ -26,11 +28,11 @@ set(SOURCES cleanup.c
             )
 
 add_custom_target(ttrpc_lib ALL
-	COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/ttrpc && cargo build --release && cp -f target/release/${TTRPC_LIB} ${CMAKE_BINARY_DIR})
+	COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/ttrpc && env OPENSSL_LIB_DIR=`dirname ${OPENSSL_SSL_LIBRARY}` OPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR} cargo build --release && cp -f target/release/${TTRPC_LIB} ${CMAKE_BINARY_DIR})
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 add_dependencies(${PROJECT_NAME} ttrpc_lib)
-target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} ${TTRPC_LIB} crypto)
+target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} ${TTRPC_LIB} OpenSSL::Crypto)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
 # Install library

--- a/cmake/CustomInstallDirs.cmake
+++ b/cmake/CustomInstallDirs.cmake
@@ -1,20 +1,19 @@
-# /usr/local
-set(RATS_INSTALL_PATH "/usr/local" CACHE STRING "Install path for librats")
+# Use CMAKE_INSTALL_PREFIX (/usr/local by default) as prefix of install path for librats
 
-# lib/rats
-set(RATS_INSTALL_LIB_PATH "${RATS_INSTALL_PATH}/lib/librats")
+# lib/librats
+set(RATS_INSTALL_LIB_PATH "${CMAKE_INSTALL_PREFIX}/lib/librats")
 
-# rats/attesters
+# librats/attesters
 set(RATS_INSTALL_LIBA_PATH "${RATS_INSTALL_LIB_PATH}/attesters")
 
-# rats/verifiers
+# librats/verifiers
 set(RATS_INSTALL_LIBV_PATH "${RATS_INSTALL_LIB_PATH}/verifiers")
 
-# rats/crypto_wrappers
+# librats/crypto_wrappers
 set(RATS_INSTALL_LIBCW_PATH "${RATS_INSTALL_LIB_PATH}/crypto_wrappers")
 
-# include/rats
-set(RATS_INSTALL_INCLUDE_PATH "${RATS_INSTALL_PATH}/include/")
+# include/librats
+set(RATS_INSTALL_INCLUDE_PATH "${CMAKE_INSTALL_PREFIX}/include/librats")
 
 # sgx sdk
 if(EXISTS $ENV{SGX_SDK})

--- a/cmake/LibCBOR.cmake
+++ b/cmake/LibCBOR.cmake
@@ -21,4 +21,5 @@ ExternalProject_Add(${PROJECT_NAME}
         CONFIGURE_COMMAND       ${LIBCBOR_CONFIGURE}
         BUILD_COMMAND           ${LIBCBOR_MAKE}
         INSTALL_COMMAND         ${LIBCBOR_INSTALL}
+        BUILD_BYPRODUCTS        ${LIBCBOR_LIB_FILES}
 )

--- a/crypto_wrappers/openssl/CMakeLists.txt
+++ b/crypto_wrappers/openssl/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Project name
 project(crypto_wrapper_openssl)
 
+if(NOT SGX AND NOT WASM)
+    find_package (OpenSSL REQUIRED)
+endif()
+
 # Set include directory
 include_directories(${INCLUDE_DIRS})
 
@@ -46,7 +50,7 @@ elseif(WASM)
     endif()
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
-    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto.so)
+    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} OpenSSL::Crypto)
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 endif()
 

--- a/samples/cert-app/CMakeLists.txt
+++ b/samples/cert-app/CMakeLists.txt
@@ -41,7 +41,6 @@ else()
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                      ${RATS_INSTALL_INCLUDE_PATH}
                      ${RATS_INSTALL_INCLUDE_PATH}/edl
-                     ${RATS_INSTALL_INCLUDE_PATH}/librats
                      )
     set(LIBRARY_DIRS ${RATS_INSTALL_LIB_PATH})
 endif()

--- a/verifiers/csv/CMakeLists.txt
+++ b/verifiers/csv/CMakeLists.txt
@@ -1,8 +1,13 @@
 # Project name
 project(verifier_csv)
 
+if(NOT WASM)
+    find_package (OpenSSL REQUIRED)
+endif()
+
 # Set include directory
-set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+set(INCLUDE_DIRS ${INCLUDE_DIRS}
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  )
@@ -42,7 +47,7 @@ if(WASM)
                        )
     endif()
 else()
-    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto)
+    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} OpenSSL::Crypto)
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 endif()
 

--- a/verifiers/sev-snp/CMakeLists.txt
+++ b/verifiers/sev-snp/CMakeLists.txt
@@ -1,8 +1,14 @@
 # Project name
 project(verifier_sev_snp)
 
+if(NOT WASM)
+    find_package (OpenSSL REQUIRED)
+    find_package (CURL REQUIRED)
+endif()
+
 # Set include directory
-set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+set(INCLUDE_DIRS ${INCLUDE_DIRS}
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10,6 +16,7 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
 if(WASM)
     list(APPEND INCLUDE_DIRS ${WASM_SRCS_DIR}/openssl/install/include)
 endif()
+
 include_directories(${INCLUDE_DIRS})
 
 # Set dependency library directory
@@ -18,9 +25,6 @@ set(LIBRARY_DIRS ${CMAKE_BINARY_DIR}
                  )
 
 link_directories(${LIBRARY_DIRS})
-
-# Set extra link library
-set(EXTRA_LINK_LIBRARY crypto curl)
 
 # Set source file
 set(SOURCES cleanup.c
@@ -48,7 +52,7 @@ if(WASM)
                          )
     endif()
 else()
-    target_link_libraries(${PROJECT_NAME} ${EXTRA_LINK_LIBRARY} ${RATS_LDFLAGS} ${RATS_LIB})
+    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} OpenSSL::Crypto CURL::libcurl)
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 endif()
 

--- a/verifiers/sev/CMakeLists.txt
+++ b/verifiers/sev/CMakeLists.txt
@@ -1,14 +1,21 @@
 # Project name
 project(verifier_sev)
 
+if(NOT WASM)
+    find_package (OpenSSL REQUIRED)
+    find_package (CURL REQUIRED)
+endif()
+
 # Set include directory
-set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+set(INCLUDE_DIRS ${INCLUDE_DIRS}
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../../include
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/librats
                  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/internal
                  )
 if(WASM)
     list(APPEND INCLUDE_DIRS ${WASM_SRCS_DIR}/openssl/install/include)
 endif()
+
 include_directories(${INCLUDE_DIRS})
 
 # Set dependency library directory
@@ -46,7 +53,7 @@ if(WASM)
                          )
    endif()
 else()
-    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} crypto curl)
+    target_link_libraries(${PROJECT_NAME} ${RATS_LDFLAGS} ${RATS_LIB} OpenSSL::Crypto CURL::libcurl)
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 endif()
 


### PR DESCRIPTION
The current CMakeLists.txt is problematic in that:
1. external dependencies (openssl, curl) are not checked with find_package().
2. no support for cmake's CMAKE_INSTALL_PREFIX, which may make it difficult to be integrated
3. some typos incorrectly write librats as rats-tls.

So, this commit refactors CMakeLists.txt and makes it more robust.

Details:
- LibCBOR.cmake: fix build
- CMakeLists.txt: add find openssl
- check openssl include
- check CURL_INCLUDE_DIRS
- CMakeLists.txt: add missing find_package curl
- CMakeLists.txt: using CURL::libcurl instead of CURL_*
- CMakeLists.txt: move find_package openssl to subdirectory
- CMakeLists.txt: using CMAKE_INSTALL_PREFIX instead of RATS_INSTALL_PATH
- remove find_package(OpenSSL) for wasm mode